### PR TITLE
feat(core): tool registration, config I/O, session resolution, statusline helpers

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,73 @@
+/**
+ * Config I/O module for mcp-server-nerf.
+ *
+ * Manages the per-session nerf configuration file at /tmp/nerf-<session_id>.json.
+ * The config schema matches what the crystallizer hook reads.
+ */
+
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+
+export interface NerfConfig {
+  mode: "not-too-rough" | "hurt-me-plenty" | "ultraviolence";
+  darts: {
+    soft: number;
+    hard: number;
+    ouch: number;
+  };
+  session_id: string;
+}
+
+export const DEFAULTS: NerfConfig = {
+  mode: "hurt-me-plenty",
+  darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+  session_id: "",
+};
+
+/**
+ * Maps doom-style mode names to crystallizer mode names.
+ */
+export const MODE_MAP: Record<string, string> = {
+  "not-too-rough": "manual",
+  "hurt-me-plenty": "prompt",
+  ultraviolence: "yolo",
+};
+
+/**
+ * Returns the config file path for a given session ID.
+ */
+export function configPath(sessionId: string): string {
+  return `/tmp/nerf-${sessionId}.json`;
+}
+
+/**
+ * Reads the config file for the given session, merging with defaults
+ * for any missing keys.
+ */
+export function readConfig(sessionId: string): NerfConfig {
+  const path = configPath(sessionId);
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<NerfConfig>;
+    return {
+      mode: parsed.mode ?? DEFAULTS.mode,
+      darts: {
+        soft: parsed.darts?.soft ?? DEFAULTS.darts.soft,
+        hard: parsed.darts?.hard ?? DEFAULTS.darts.hard,
+        ouch: parsed.darts?.ouch ?? DEFAULTS.darts.ouch,
+      },
+      session_id: parsed.session_id ?? DEFAULTS.session_id,
+    };
+  } catch {
+    return { ...DEFAULTS, session_id: sessionId };
+  }
+}
+
+/**
+ * Writes the config file atomically (write to .tmp, rename).
+ */
+export function writeConfig(sessionId: string, config: NerfConfig): void {
+  const path = configPath(sessionId);
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+  renameSync(tmpPath, path);
+}

--- a/index.ts
+++ b/index.ts
@@ -1,18 +1,134 @@
 #!/usr/bin/env bun
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Tool schemas for the nerf MCP server.
+ *
+ * Each tool has a name, description, and inputSchema with typed parameters.
+ * Handlers are stubs — actual logic comes in later issues (#220-#223).
+ */
+export const TOOLS: Tool[] = [
+  {
+    name: "nerf_status",
+    description: "Show current mode, dart thresholds, and context usage",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "nerf_mode",
+    description:
+      "Get or set the behavior mode (not-too-rough, hurt-me-plenty, ultraviolence)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["not-too-rough", "hurt-me-plenty", "ultraviolence"],
+          description:
+            "The mode to set. Omit to return current mode.",
+        },
+      },
+    },
+  },
+  {
+    name: "nerf_darts",
+    description: "Get or set individual dart thresholds (soft, hard, ouch)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        soft: {
+          type: "number",
+          description: "Soft dart threshold (token count)",
+        },
+        hard: {
+          type: "number",
+          description: "Hard dart threshold (token count)",
+        },
+        ouch: {
+          type: "number",
+          description: "Ouch dart threshold (token count)",
+        },
+      },
+    },
+  },
+  {
+    name: "nerf_budget",
+    description:
+      "Set the ouch dart with proportional scaling of soft and hard thresholds",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        ouch: {
+          type: "number",
+          description: "The ouch (max) dart threshold to set",
+        },
+      },
+      required: ["ouch"],
+    },
+  },
+  {
+    name: "nerf_scope",
+    description: "Launch the context monitor to track token usage over time",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        interval: {
+          type: "number",
+          description: "Polling interval in milliseconds (default: 30000)",
+        },
+      },
+    },
+  },
+];
+
+/**
+ * Stub handler map — routes tool name to a handler function.
+ * Returns "not implemented" for all tools until later issues add logic.
+ */
+const HANDLERS: Record<
+  string,
+  (params: Record<string, unknown>) => Promise<string>
+> = {
+  nerf_status: async () => "not implemented",
+  nerf_mode: async () => "not implemented",
+  nerf_darts: async () => "not implemented",
+  nerf_budget: async () => "not implemented",
+  nerf_scope: async () => "not implemented",
+};
 
 const server = new Server(
   { name: "nerf-server", version: "1.0.0" },
   { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
-server.setRequestHandler(CallToolRequestSchema, async (request) => ({
-  content: [{ type: "text", text: `Unknown tool: ${request.params.name}` }],
-  isError: true,
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: TOOLS,
 }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const handler = HANDLERS[name];
+
+  if (!handler) {
+    return {
+      content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+
+  const result = await handler((args ?? {}) as Record<string, unknown>);
+  return {
+    content: [{ type: "text" as const, text: result }],
+  };
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/session.ts
+++ b/session.ts
@@ -1,0 +1,70 @@
+/**
+ * Session ID resolution for mcp-server-nerf.
+ *
+ * Resolves the Claude Code session ID from the environment, filesystem
+ * artifacts, or generates a stable fallback.
+ */
+
+import { readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+
+/**
+ * Resolve the session ID from the Claude Code environment.
+ *
+ * Strategy:
+ * 1. Check CLAUDE_SESSION_ID env var (set by some Claude Code configurations)
+ * 2. Scan /tmp for claude session artifacts (transcript/output files)
+ * 3. Fallback: generate a stable ID from PID + process start time
+ */
+export function resolveSessionId(): string {
+  // 1. Direct env var
+  const envId = process.env.CLAUDE_SESSION_ID;
+  if (envId) {
+    return envId;
+  }
+
+  // 2. Scan /tmp for session artifacts
+  const scanned = scanForSessionArtifacts();
+  if (scanned) {
+    return scanned;
+  }
+
+  // 3. Fallback: stable ID from PID + timestamp
+  return generateStableId();
+}
+
+/**
+ * Scan /tmp for Claude session artifacts and extract a session ID.
+ * Looks for files matching claude-session-* or similar patterns.
+ */
+function scanForSessionArtifacts(): string | null {
+  try {
+    const entries = readdirSync("/tmp");
+    // Look for nerf config files first (nerf-<session_id>.json)
+    for (const entry of entries) {
+      const match = entry.match(/^nerf-([a-f0-9-]+)\.json$/);
+      if (match) {
+        return match[1];
+      }
+    }
+    // Look for claude session markers
+    for (const entry of entries) {
+      const match = entry.match(/^claude-session-([a-f0-9-]+)/);
+      if (match) {
+        return match[1];
+      }
+    }
+  } catch {
+    // /tmp not readable — fall through
+  }
+  return null;
+}
+
+/**
+ * Generate a stable ID from process characteristics.
+ * Uses PID and a fixed seed so the ID is deterministic within a process.
+ */
+function generateStableId(): string {
+  const seed = `${process.pid}-${process.ppid ?? 0}`;
+  return createHash("md5").update(seed).digest("hex").slice(0, 12);
+}

--- a/statusline.ts
+++ b/statusline.ts
@@ -1,0 +1,130 @@
+/**
+ * Statusline indicator helpers for mcp-server-nerf.
+ *
+ * Manages indicators in the Claude Code statusline JSON file.
+ * Follows the same pattern as mcp-server-wtf for atomic read-modify-write.
+ */
+
+import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+
+interface StatuslineData {
+  indicators: string[];
+}
+
+/**
+ * Resolve the project root via git.
+ */
+export function resolveProjectRoot(): string {
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+/**
+ * Resolve the dev name from the agent identity file.
+ * Reads /tmp/claude-agent-<dir_hash>.json where dir_hash is md5 of project root.
+ */
+export function resolveDevName(): string | null {
+  try {
+    const projectRoot = resolveProjectRoot();
+    const dirHash = createHash("md5").update(projectRoot).digest("hex");
+    const agentFile = `/tmp/claude-agent-${dirHash}.json`;
+    const raw = readFileSync(agentFile, "utf-8");
+    const data = JSON.parse(raw) as { dev_name?: string };
+    return data.dev_name ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the statusline file path for the current agent.
+ * Returns /tmp/claude-statusline-<dev_name>.json or null if dev name cannot be resolved.
+ */
+export function resolveStatuslineFile(): string | null {
+  const devName = resolveDevName();
+  if (!devName) return null;
+  return `/tmp/claude-statusline-${devName}.json`;
+}
+
+/**
+ * Read the statusline data from the given file path.
+ */
+function readStatusline(filePath: string): StatuslineData {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw) as Partial<StatuslineData>;
+    return { indicators: Array.isArray(data.indicators) ? data.indicators : [] };
+  } catch {
+    return { indicators: [] };
+  }
+}
+
+/**
+ * Write statusline data atomically (write to .tmp, rename).
+ */
+function writeStatusline(filePath: string, data: StatuslineData): void {
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Add an indicator to the statusline. Idempotent — will not add duplicates.
+ * If the statusline file cannot be resolved, this is a no-op.
+ */
+export function addIndicator(indicator: string): void {
+  const filePath = resolveStatuslineFile();
+  if (!filePath) return;
+
+  const data = readStatusline(filePath);
+  if (!data.indicators.includes(indicator)) {
+    data.indicators.push(indicator);
+  }
+  writeStatusline(filePath, data);
+}
+
+/**
+ * Remove indicators matching the given prefix from the statusline.
+ * If the statusline file cannot be resolved, this is a no-op.
+ */
+export function removeIndicator(prefix: string): void {
+  const filePath = resolveStatuslineFile();
+  if (!filePath) return;
+
+  const data = readStatusline(filePath);
+  data.indicators = data.indicators.filter((ind) => !ind.startsWith(prefix));
+  writeStatusline(filePath, data);
+}
+
+// --- Overloads for testing with explicit file paths ---
+
+/**
+ * Add an indicator to a specific statusline file. Idempotent.
+ */
+export function addIndicatorToFile(filePath: string, indicator: string): void {
+  const data = readStatusline(filePath);
+  if (!data.indicators.includes(indicator)) {
+    data.indicators.push(indicator);
+  }
+  writeStatusline(filePath, data);
+}
+
+/**
+ * Remove indicators matching the given prefix from a specific statusline file.
+ */
+export function removeIndicatorFromFile(
+  filePath: string,
+  prefix: string,
+): void {
+  const data = readStatusline(filePath);
+  data.indicators = data.indicators.filter((ind) => !ind.startsWith(prefix));
+  writeStatusline(filePath, data);
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for config.ts — Config I/O module.
+ *
+ * Tests use real filesystem operations in a temp directory.
+ * No mocking of internal modules.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  readConfig,
+  writeConfig,
+  configPath,
+  DEFAULTS,
+  MODE_MAP,
+  type NerfConfig,
+} from "../config.ts";
+
+/**
+ * We test readConfig/writeConfig by creating a unique session ID per test
+ * that maps to /tmp/nerf-<id>.json. After each test we clean up.
+ */
+describe("config", () => {
+  let testSessionId: string;
+
+  beforeEach(() => {
+    testSessionId = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  });
+
+  afterEach(() => {
+    const path = configPath(testSessionId);
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      // ignore
+    }
+    try {
+      rmSync(`${path}.tmp`, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test("configPath returns correct path", () => {
+    expect(configPath("abc123")).toBe("/tmp/nerf-abc123.json");
+  });
+
+  test("readConfig returns defaults when no file exists", () => {
+    const config = readConfig(testSessionId);
+    expect(config.mode).toBe(DEFAULTS.mode);
+    expect(config.darts.soft).toBe(DEFAULTS.darts.soft);
+    expect(config.darts.hard).toBe(DEFAULTS.darts.hard);
+    expect(config.darts.ouch).toBe(DEFAULTS.darts.ouch);
+    expect(config.session_id).toBe(testSessionId);
+  });
+
+  test("writeConfig creates a valid JSON file", () => {
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 100_000, hard: 130_000, ouch: 180_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const path = configPath(testSessionId);
+    expect(existsSync(path)).toBe(true);
+
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.mode).toBe("ultraviolence");
+    expect(parsed.darts.soft).toBe(100_000);
+  });
+
+  test("readConfig round-trips with writeConfig", () => {
+    const config: NerfConfig = {
+      mode: "not-too-rough",
+      darts: { soft: 80_000, hard: 100_000, ouch: 150_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+    const read = readConfig(testSessionId);
+    expect(read).toEqual(config);
+  });
+
+  test("readConfig merges partial config with defaults", () => {
+    // Write a partial config (missing darts.hard and mode)
+    const path = configPath(testSessionId);
+    const partial = {
+      darts: { soft: 90_000, ouch: 170_000 },
+      session_id: testSessionId,
+    };
+    const { writeFileSync } = require("node:fs");
+    writeFileSync(path, JSON.stringify(partial), "utf-8");
+
+    const config = readConfig(testSessionId);
+    expect(config.mode).toBe(DEFAULTS.mode); // filled from defaults
+    expect(config.darts.soft).toBe(90_000); // from file
+    expect(config.darts.hard).toBe(DEFAULTS.darts.hard); // filled from defaults
+    expect(config.darts.ouch).toBe(170_000); // from file
+  });
+
+  test("writeConfig is atomic (no .tmp file remains)", () => {
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const tmpPath = `${configPath(testSessionId)}.tmp`;
+    expect(existsSync(tmpPath)).toBe(false);
+    expect(existsSync(configPath(testSessionId))).toBe(true);
+  });
+
+  test("DEFAULTS match crystallizer schema shape", () => {
+    // Verify the config shape has the fields the crystallizer expects
+    expect(DEFAULTS).toHaveProperty("mode");
+    expect(DEFAULTS).toHaveProperty("darts");
+    expect(DEFAULTS).toHaveProperty("session_id");
+    expect(DEFAULTS.darts).toHaveProperty("soft");
+    expect(DEFAULTS.darts).toHaveProperty("hard");
+    expect(DEFAULTS.darts).toHaveProperty("ouch");
+    expect(typeof DEFAULTS.mode).toBe("string");
+    expect(typeof DEFAULTS.darts.soft).toBe("number");
+    expect(typeof DEFAULTS.darts.hard).toBe("number");
+    expect(typeof DEFAULTS.darts.ouch).toBe("number");
+  });
+
+  test("MODE_MAP has correct mappings", () => {
+    expect(MODE_MAP["not-too-rough"]).toBe("manual");
+    expect(MODE_MAP["hurt-me-plenty"]).toBe("prompt");
+    expect(MODE_MAP["ultraviolence"]).toBe("yolo");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,8 +1,8 @@
 /**
- * Unit tests for the Nerf MCP server stub.
+ * Unit tests for the Nerf MCP server tool registration.
  *
  * Verifies that the server initializes correctly and returns
- * an empty tool list as expected for the initial scaffold.
+ * the registered tool schemas.
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
@@ -13,6 +13,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { TOOLS } from "../index.ts";
 
 function createServer(): Server {
   const server = new Server(
@@ -20,16 +21,39 @@ function createServer(): Server {
     { capabilities: { tools: {} } }
   );
 
+  const HANDLERS: Record<
+    string,
+    (params: Record<string, unknown>) => Promise<string>
+  > = {
+    nerf_status: async () => "not implemented",
+    nerf_mode: async () => "not implemented",
+    nerf_darts: async () => "not implemented",
+    nerf_budget: async () => "not implemented",
+    nerf_scope: async () => "not implemented",
+  };
+
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [],
+    tools: TOOLS,
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => ({
-    content: [
-      { type: "text", text: `Unknown tool: ${request.params.name}` },
-    ],
-    isError: true,
-  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const handler = HANDLERS[name];
+
+    if (!handler) {
+      return {
+        content: [
+          { type: "text" as const, text: `Unknown tool: ${name}` },
+        ],
+        isError: true,
+      };
+    }
+
+    const result = await handler((args ?? {}) as Record<string, unknown>);
+    return {
+      content: [{ type: "text" as const, text: result }],
+    };
+  });
 
   return server;
 }
@@ -65,9 +89,43 @@ describe("nerf server", () => {
     expect(client).toBeDefined();
   });
 
-  test("list tools returns empty", async () => {
+  test("list tools returns 5 tools", async () => {
     await connectPair();
     const result = await client.listTools();
-    expect(result.tools).toEqual([]);
+    expect(result.tools).toHaveLength(5);
+  });
+
+  test("tool names are correct", async () => {
+    await connectPair();
+    const result = await client.listTools();
+    const names = result.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "nerf_budget",
+      "nerf_darts",
+      "nerf_mode",
+      "nerf_scope",
+      "nerf_status",
+    ]);
+  });
+
+  test("calling a registered tool returns not implemented", async () => {
+    await connectPair();
+    const result = await client.callTool({ name: "nerf_status", arguments: {} });
+    expect(result.content).toEqual([
+      { type: "text", text: "not implemented" },
+    ]);
+    expect(result.isError).toBeFalsy();
+  });
+
+  test("calling an unknown tool returns error", async () => {
+    await connectPair();
+    const result = await client.callTool({
+      name: "nonexistent_tool",
+      arguments: {},
+    });
+    expect(result.content).toEqual([
+      { type: "text", text: "Unknown tool: nonexistent_tool" },
+    ]);
+    expect(result.isError).toBe(true);
   });
 });

--- a/tests/statusline.test.ts
+++ b/tests/statusline.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for statusline.ts — Statusline indicator helpers.
+ *
+ * Tests use real filesystem operations with temp files.
+ * The addIndicatorToFile/removeIndicatorFromFile overloads are tested
+ * directly to avoid needing agent identity files for every test.
+ * resolveDevName is tested with a mock agent file.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import {
+  addIndicatorToFile,
+  removeIndicatorFromFile,
+  resolveDevName,
+  resolveProjectRoot,
+  resolveStatuslineFile,
+} from "../statusline.ts";
+
+describe("statusline", () => {
+  let tempDir: string;
+  let statusFile: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "nerf-statusline-test-"));
+    statusFile = join(tempDir, "statusline.json");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("addIndicatorToFile creates file with indicator array", () => {
+    addIndicatorToFile(statusFile, "nerf:active");
+
+    expect(existsSync(statusFile)).toBe(true);
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual(["nerf:active"]);
+  });
+
+  test("addIndicatorToFile is idempotent", () => {
+    addIndicatorToFile(statusFile, "nerf:active");
+    addIndicatorToFile(statusFile, "nerf:active");
+
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual(["nerf:active"]);
+  });
+
+  test("removeIndicatorFromFile cleans up matching indicators", () => {
+    addIndicatorToFile(statusFile, "nerf:active");
+    addIndicatorToFile(statusFile, "nerf:scope");
+    removeIndicatorFromFile(statusFile, "nerf:active");
+
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual(["nerf:scope"]);
+  });
+
+  test("removeIndicatorFromFile removes by prefix", () => {
+    addIndicatorToFile(statusFile, "nerf:active");
+    addIndicatorToFile(statusFile, "nerf:scope");
+    addIndicatorToFile(statusFile, "wtf:investigating");
+    removeIndicatorFromFile(statusFile, "nerf:");
+
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual(["wtf:investigating"]);
+  });
+
+  test("multiple indicators from different sources coexist", () => {
+    addIndicatorToFile(statusFile, "nerf:active");
+    addIndicatorToFile(statusFile, "wtf:investigating");
+    addIndicatorToFile(statusFile, "cryo:freezing");
+
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toHaveLength(3);
+    expect(data.indicators).toContain("nerf:active");
+    expect(data.indicators).toContain("wtf:investigating");
+    expect(data.indicators).toContain("cryo:freezing");
+  });
+
+  test("removeIndicatorFromFile on empty file is safe", () => {
+    // File doesn't exist yet — should not throw
+    removeIndicatorFromFile(statusFile, "nerf:");
+    expect(existsSync(statusFile)).toBe(true);
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual([]);
+  });
+
+  test("addIndicatorToFile preserves existing indicators from other sources", () => {
+    // Pre-populate with an existing indicator
+    writeFileSync(
+      statusFile,
+      JSON.stringify({ indicators: ["wtf:active"] }),
+      "utf-8"
+    );
+
+    addIndicatorToFile(statusFile, "nerf:monitoring");
+
+    const data = JSON.parse(readFileSync(statusFile, "utf-8"));
+    expect(data.indicators).toEqual(["wtf:active", "nerf:monitoring"]);
+  });
+
+  test("resolveProjectRoot returns a string", () => {
+    const root = resolveProjectRoot();
+    expect(typeof root).toBe("string");
+    expect(root.length).toBeGreaterThan(0);
+  });
+
+  test("resolveDevName with mock agent file", () => {
+    // Create a mock agent file keyed to the current project root
+    const projectRoot = resolveProjectRoot();
+    const dirHash = createHash("md5").update(projectRoot).digest("hex");
+    const agentFile = `/tmp/claude-agent-${dirHash}.json`;
+
+    // Check if file already exists (from real session) — preserve and restore
+    let originalContent: string | null = null;
+    try {
+      originalContent = readFileSync(agentFile, "utf-8");
+    } catch {
+      // doesn't exist
+    }
+
+    try {
+      writeFileSync(
+        agentFile,
+        JSON.stringify({ dev_name: "test-nerf-agent", dev_avatar: "🧪", dev_team: "test" }),
+        "utf-8"
+      );
+
+      const devName = resolveDevName();
+      expect(devName).toBe("test-nerf-agent");
+    } finally {
+      // Restore original or clean up
+      if (originalContent !== null) {
+        writeFileSync(agentFile, originalContent, "utf-8");
+      } else {
+        try {
+          rmSync(agentFile, { force: true });
+        } catch {
+          // ignore
+        }
+      }
+    }
+  });
+
+  test("resolveDevName returns null when no agent file exists", () => {
+    // Use a directory that won't have an agent file
+    const fakeRoot = "/tmp/nonexistent-project-root-for-test";
+    const dirHash = createHash("md5").update(fakeRoot).digest("hex");
+    const agentFile = `/tmp/claude-agent-${dirHash}.json`;
+
+    // Make sure it doesn't exist
+    try {
+      rmSync(agentFile, { force: true });
+    } catch {
+      // ignore
+    }
+
+    // resolveDevName uses the real project root, not fakeRoot.
+    // So we test the null path by checking it doesn't crash when file is missing.
+    // The actual null test is implicitly covered if no agent file exists.
+    // For a stronger test, we verify the function type:
+    const result = resolveDevName();
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+
+  test("resolveStatuslineFile returns path or null", () => {
+    const result = resolveStatuslineFile();
+    if (result !== null) {
+      expect(result).toMatch(/^\/tmp\/claude-statusline-.+\.json$/);
+    }
+    // null is also acceptable if no agent file exists
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "outDir": "dist",
     "declaration": true,
     "types": ["bun"]


### PR DESCRIPTION
## Summary

Implement the core MCP server infrastructure: 5-tool registration framework with stub handlers, config file I/O (compatible with crystallizer hook), session ID resolution, and statusline indicator helpers with atomic read-modify-write.

## Changes

- `config.ts` — NerfConfig interface, readConfig (defaults-merging), writeConfig (atomic via tmp+rename), DEFAULTS (120k/150k/200k), MODE_MAP (doom→crystallizer)
- `session.ts` — resolveSessionId from CLAUDE_SESSION_ID env, /tmp artifact scan, PID-based stable fallback
- `statusline.ts` — resolveDevName, resolveStatuslineFile, addIndicator/removeIndicator with prefix matching and atomic write
- `index.ts` — 5 tool schemas (nerf_status, nerf_mode, nerf_darts, nerf_budget, nerf_scope) with inputSchema and stub handlers
- `tests/config.test.ts` — 8 tests: defaults, roundtrip, partial merge, atomicity, schema shape, MODE_MAP
- `tests/statusline.test.ts` — 11 tests: add/remove, idempotency, prefix, coexistence, resolveDevName
- `tests/server.test.ts` — Updated to expect 5 tools, added tool name and handler tests

## Test Results

```
24 pass, 0 fail, 54 expect() calls (219ms)
bun run lint — clean
```

Closes Wave-Engineering/claudecode-workflow#219

🤖 Generated with [Claude Code](https://claude.com/claude-code)