### PR TITLE
feat(context): context usage estimation via context-analyzer.sh

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -1,0 +1,135 @@
+/**
+ * context.ts — Context usage estimation module
+ *
+ * Shells out to context-analyzer.sh to estimate token usage for a Claude Code
+ * session. Returns { total, limit, percent } or null on any error.
+ *
+ * This module is standalone — consumed by nerf_status but not wired into
+ * index.ts directly.
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface ContextUsage {
+  total: number;
+  limit: number;
+  percent: number;
+}
+
+/** Path to the context-analyzer.sh script. */
+const ANALYZER_PATH = join(
+  homedir(),
+  ".claude",
+  "context-crystallizer",
+  "lib",
+  "context-analyzer.sh",
+);
+
+/** Directory containing Claude Code project transcript files. */
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+
+/**
+ * Locate the transcript JSONL file for a given session ID.
+ *
+ * Claude Code stores transcripts as `<session_id>.jsonl` under
+ * `~/.claude/projects/<project-slug>/`. We search all project directories
+ * for a matching file.
+ *
+ * Returns the absolute path or null if not found.
+ */
+function findTranscript(sessionId: string): string | null {
+  if (!existsSync(PROJECTS_DIR)) {
+    return null;
+  }
+
+  try {
+    // Use find to locate the transcript — same approach as cc-context
+    const result = execSync(
+      `find "${PROJECTS_DIR}" -name "${sessionId}.jsonl" -type f 2>/dev/null | head -1`,
+      { encoding: "utf-8", timeout: 5000 },
+    ).trim();
+
+    return result.length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse the JSON output from context-analyzer.sh into a ContextUsage.
+ *
+ * The analyzer returns nested JSON:
+ *   { tokens: { total: N }, limit: N, percent: N }
+ *
+ * We map tokens.total -> total.
+ */
+function parseAnalyzerOutput(raw: string): ContextUsage | null {
+  try {
+    const data = JSON.parse(raw);
+
+    // Reject error responses from the analyzer
+    if (data.error) {
+      return null;
+    }
+
+    const total = data?.tokens?.total;
+    const limit = data?.limit;
+    const percent = data?.percent;
+
+    if (typeof total !== "number" || typeof limit !== "number" || typeof percent !== "number") {
+      return null;
+    }
+
+    return { total, limit, percent };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Estimate context usage for a Claude Code session.
+ *
+ * Shells out to context-analyzer.sh with the session's transcript path.
+ * Returns { total, limit, percent } on success, or null if estimation is
+ * unavailable for any reason (missing transcript, missing analyzer, parse
+ * error, etc.).
+ *
+ * This function NEVER throws.
+ */
+export async function getContextUsage(
+  sessionId: string,
+): Promise<ContextUsage | null> {
+  try {
+    // Resolve the analyzer script path — allow override for testing
+    const analyzerPath =
+      process.env.NERF_ANALYZER_PATH ?? ANALYZER_PATH;
+
+    // Verify the analyzer script exists
+    if (!existsSync(analyzerPath)) {
+      return null;
+    }
+
+    // Find the transcript for this session
+    const transcript = findTranscript(sessionId);
+    if (!transcript) {
+      return null;
+    }
+
+    // Shell out to the analyzer
+    // The analyzer is a bash library — source it and call analyze_context
+    const cmd = `bash -c 'source "${analyzerPath}" && analyze_context "${transcript}"'`;
+
+    const raw = execSync(cmd, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+
+    return parseAnalyzerOutput(raw);
+  } catch {
+    return null;
+  }
+}

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for context.ts — Context usage estimation module
+ *
+ * Testing strategy:
+ *   - "returns null when no transcript" and "returns null when analyzer missing":
+ *     Test real behavior with nonexistent paths/sessions.
+ *   - "parses valid analyzer output": Create a temp shell script that echoes
+ *     known JSON, point the function at it via NERF_ANALYZER_PATH env var.
+ *   - "handles malformed output": Same approach with bad JSON.
+ */
+
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { getContextUsage } from "../context";
+
+describe("getContextUsage", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore environment after each test
+    process.env.NERF_ANALYZER_PATH = originalEnv.NERF_ANALYZER_PATH;
+  });
+
+  test("returns null when no transcript exists", async () => {
+    // Use a session ID that cannot possibly exist
+    const result = await getContextUsage("nonexistent-session-id-000000");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when analyzer script is missing", async () => {
+    // Point NERF_ANALYZER_PATH at a nonexistent file
+    process.env.NERF_ANALYZER_PATH = "/tmp/nonexistent-analyzer-script.sh";
+    const result = await getContextUsage("any-session-id");
+    expect(result).toBeNull();
+  });
+
+  test("parses valid analyzer output", async () => {
+    // Create a temp directory with a fake analyzer and transcript
+    const tempDir = mkdtempSync(join(tmpdir(), "nerf-test-"));
+    const sessionId = "test-valid-parse-session";
+
+    try {
+      // Create a fake analyzer script that echoes known JSON
+      const fakeAnalyzer = join(tempDir, "fake-analyzer.sh");
+      writeFileSync(
+        fakeAnalyzer,
+        `#!/bin/bash
+analyze_context() {
+  cat <<'ENDJSON'
+{
+  "tokens": {
+    "input": 40000,
+    "cache_create": 8000,
+    "cache_read": 2000,
+    "output": 1500,
+    "total": 50000
+  },
+  "limit": 200000,
+  "percent": 40.0,
+  "action": "none"
+}
+ENDJSON
+}
+`,
+      );
+      chmodSync(fakeAnalyzer, 0o755);
+
+      // Create a fake transcript at the expected location
+      const projectsDir = join(homedir(), ".claude", "projects");
+      // Find an existing project slug directory to place our transcript
+      // (or create a temp one under projects)
+      const fakeProjectDir = join(projectsDir, "-tmp-nerf-test");
+      const transcriptPath = join(fakeProjectDir, `${sessionId}.jsonl`);
+
+      // Create the directory and transcript
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(fakeProjectDir, { recursive: true });
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-sonnet-4-20250514",
+            usage: {
+              input_tokens: 40000,
+              cache_creation_input_tokens: 8000,
+              cache_read_input_tokens: 2000,
+              output_tokens: 1500,
+            },
+          },
+        }) + "\n",
+      );
+
+      // Point the function at our fake analyzer
+      process.env.NERF_ANALYZER_PATH = fakeAnalyzer;
+
+      const result = await getContextUsage(sessionId);
+
+      expect(result).not.toBeNull();
+      expect(result!.total).toBe(50000);
+      expect(result!.limit).toBe(200000);
+      expect(result!.percent).toBe(40.0);
+
+      // Cleanup transcript and directory
+      rmSync(transcriptPath, { force: true });
+      rmSync(fakeProjectDir, { recursive: true, force: true });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles malformed analyzer output", async () => {
+    // Create a fake analyzer that outputs invalid JSON
+    const tempDir = mkdtempSync(join(tmpdir(), "nerf-test-malformed-"));
+    const sessionId = "test-malformed-session";
+
+    try {
+      const fakeAnalyzer = join(tempDir, "bad-analyzer.sh");
+      writeFileSync(
+        fakeAnalyzer,
+        `#!/bin/bash
+analyze_context() {
+  echo "THIS IS NOT JSON {{{{"
+}
+`,
+      );
+      chmodSync(fakeAnalyzer, 0o755);
+
+      // Create a fake transcript so we get past the transcript-finding step
+      const projectsDir = join(homedir(), ".claude", "projects");
+      const fakeProjectDir = join(projectsDir, "-tmp-nerf-test-malformed");
+      const transcriptPath = join(fakeProjectDir, `${sessionId}.jsonl`);
+
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(fakeProjectDir, { recursive: true });
+      writeFileSync(transcriptPath, '{"type":"assistant"}\n');
+
+      process.env.NERF_ANALYZER_PATH = fakeAnalyzer;
+
+      const result = await getContextUsage(sessionId);
+      expect(result).toBeNull();
+
+      // Cleanup
+      rmSync(transcriptPath, { force: true });
+      rmSync(fakeProjectDir, { recursive: true, force: true });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Context usage estimation module that shells out to `context-analyzer.sh` to get token counts for a Claude Code session. Returns `{ total, limit, percent }` or `null` on any error. Standalone module — not wired into index.ts; consumed by `nerf_status` (#220).

## Changes

- `context.ts` — `getContextUsage(sessionId)`, `parseAnalyzerOutput()`, `findTranscript()`, `ContextUsage` interface
- `tests/context.test.ts` — 4 tests: null transcript, missing analyzer, valid parse, malformed output

## Test Results

44 tests pass (24 prior + 4 new context + 16 from parallel #220 work present in worktree)

Closes #223

Generated with [Claude Code](https://claude.com/claude-code)