### PR TITLE
feat(tools): nerf_status + nerf_mode tool handlers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,8 @@ import {
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { handleStatus } from "./status.ts";
+import { handleMode } from "./mode.ts";
 
 /**
  * Tool schemas for the nerf MCP server.
@@ -97,8 +99,8 @@ const HANDLERS: Record<
   string,
   (params: Record<string, unknown>) => Promise<string>
 > = {
-  nerf_status: async () => "not implemented",
-  nerf_mode: async () => "not implemented",
+  nerf_status: async (params) => handleStatus(params),
+  nerf_mode: async (params) => handleMode(params),
   nerf_darts: async () => "not implemented",
   nerf_budget: async () => "not implemented",
   nerf_scope: async () => "not implemented",

--- a/mode.ts
+++ b/mode.ts
@@ -1,0 +1,75 @@
+/**
+ * nerf_mode tool handler.
+ *
+ * Gets or sets the behavior mode. Validates mode names and maps
+ * doom-style names to crystallizer mode names.
+ */
+
+import {
+  readConfig,
+  writeConfig,
+  MODE_MAP,
+  type NerfConfig,
+} from "./config.ts";
+import { resolveSessionId } from "./session.ts";
+
+const VALID_MODES: NerfConfig["mode"][] = [
+  "not-too-rough",
+  "hurt-me-plenty",
+  "ultraviolence",
+];
+
+/**
+ * Mode descriptions for display.
+ */
+const MODE_DESCRIPTIONS: Record<string, string> = {
+  "not-too-rough": "manual crystallization — you decide when to save state",
+  "hurt-me-plenty": "prompted crystallization — reminders at thresholds",
+  ultraviolence: "auto-crystallize — yolo mode, saves state automatically",
+};
+
+/**
+ * Handle the nerf_mode tool call.
+ *
+ * - No `mode` arg: return current mode name and description
+ * - With `mode` arg: validate, write to config, return confirmation
+ */
+export async function handleMode(
+  params: Record<string, unknown>,
+): Promise<string> {
+  const sessionId = resolveSessionId();
+  const config = readConfig(sessionId);
+
+  const requestedMode = params.mode as string | undefined;
+
+  // No mode arg — return current mode
+  if (requestedMode === undefined) {
+    const description = MODE_DESCRIPTIONS[config.mode] ?? "unknown mode";
+    const crystallizerMode = MODE_MAP[config.mode] ?? "unknown";
+    return [
+      `Current mode: ${config.mode}`,
+      `Description: ${description}`,
+      `CRYSTALLIZE_MODE: ${crystallizerMode}`,
+    ].join("\n");
+  }
+
+  // Validate mode
+  if (!VALID_MODES.includes(requestedMode as NerfConfig["mode"])) {
+    return `Invalid mode: "${requestedMode}". Valid modes: ${VALID_MODES.join(", ")}`;
+  }
+
+  // Set mode
+  const newConfig: NerfConfig = {
+    ...config,
+    mode: requestedMode as NerfConfig["mode"],
+  };
+  writeConfig(sessionId, newConfig);
+
+  const description = MODE_DESCRIPTIONS[requestedMode] ?? "unknown mode";
+  const crystallizerMode = MODE_MAP[requestedMode] ?? "unknown";
+  return [
+    `Mode set: ${requestedMode}`,
+    `Description: ${description}`,
+    `CRYSTALLIZE_MODE: ${crystallizerMode}`,
+  ].join("\n");
+}

--- a/status.ts
+++ b/status.ts
@@ -1,0 +1,127 @@
+/**
+ * nerf_status tool handler.
+ *
+ * Returns formatted display of current mode, dart thresholds, and context usage.
+ * Updates statusline indicator based on context level.
+ */
+
+import { readConfig, MODE_MAP, type NerfConfig } from "./config.ts";
+import { resolveSessionId } from "./session.ts";
+import { addIndicator, removeIndicator } from "./statusline.ts";
+
+/**
+ * Format a token count for human-readable display.
+ * e.g., 120000 → "120k", 1500 → "2k", 200000 → "200k"
+ */
+export function formatTokenCount(value: number): string {
+  return Math.round(value / 1000) + "k";
+}
+
+/**
+ * Attempt to get context usage. Returns null if the context module
+ * is not available (#223 may not be merged yet).
+ *
+ * Uses a runtime-only path string to avoid TypeScript compile-time errors
+ * when context.ts does not exist.
+ */
+async function getContextUsage(): Promise<{
+  used: number;
+  total: number;
+} | null> {
+  try {
+    // Build the path at runtime so tsc doesn't resolve it at compile time
+    const contextModule = "./context" + ".ts";
+    const mod = await import(/* @vite-ignore */ contextModule);
+    if (typeof mod.getContextUsage === "function") {
+      const result = mod.getContextUsage();
+      return result ?? null;
+    }
+  } catch {
+    // context.ts not available — #223 not merged yet
+  }
+  return null;
+}
+
+/**
+ * Mode descriptions for display.
+ */
+const MODE_DESCRIPTIONS: Record<string, string> = {
+  "not-too-rough": "manual crystallization — you decide when to save state",
+  "hurt-me-plenty": "prompted crystallization — reminders at thresholds",
+  ultraviolence: "auto-crystallize — yolo mode, saves state automatically",
+};
+
+/**
+ * Update statusline indicator based on context usage level.
+ * Removes any existing nerf context indicator first, then adds the
+ * appropriate one (if any).
+ */
+function updateStatuslineIndicator(
+  contextUsage: { used: number; total: number } | null,
+  config: NerfConfig,
+): void {
+  // Remove any existing nerf context indicators
+  removeIndicator("⚡");
+  removeIndicator("🔶");
+  removeIndicator("🚨");
+
+  if (!contextUsage) return;
+
+  const { used } = contextUsage;
+  const { soft, hard, ouch } = config.darts;
+
+  if (used >= ouch * 0.85) {
+    const pct = Math.round((used / ouch) * 100);
+    addIndicator(`🚨 ${pct}%`);
+  } else if (used >= hard) {
+    const pct = Math.round((used / ouch) * 100);
+    addIndicator(`🔶 ${pct}%`);
+  } else if (used >= soft) {
+    const pct = Math.round((used / ouch) * 100);
+    addIndicator(`⚡ ${pct}%`);
+  }
+  // Below soft: no indicator (no clutter when healthy)
+}
+
+/**
+ * Handle the nerf_status tool call.
+ */
+export async function handleStatus(
+  _params: Record<string, unknown>,
+): Promise<string> {
+  const sessionId = resolveSessionId();
+  const config = readConfig(sessionId);
+  const modeName = config.mode;
+  const modeDescription =
+    MODE_DESCRIPTIONS[modeName] ?? "unknown mode";
+
+  const contextUsage = await getContextUsage();
+
+  // Update statusline indicator
+  updateStatuslineIndicator(contextUsage, config);
+
+  // Format dart values
+  const softStr = formatTokenCount(config.darts.soft);
+  const hardStr = formatTokenCount(config.darts.hard);
+  const ouchStr = formatTokenCount(config.darts.ouch);
+
+  // Format context line
+  let contextLine: string;
+  if (contextUsage) {
+    const pct = Math.round((contextUsage.used / config.darts.ouch) * 100);
+    contextLine = `Context: ${formatTokenCount(contextUsage.used)}/${ouchStr} (${pct}%)`;
+  } else {
+    contextLine = "Context: unavailable";
+  }
+
+  return [
+    `nerf — ${modeName} (${modeDescription})`,
+    "",
+    "Darts:",
+    `  soft   ${softStr}   warning`,
+    `  hard   ${hardStr}   crystallize`,
+    `  ouch   ${ouchStr}   compact or die`,
+    "",
+    contextLine,
+  ].join("\n");
+}

--- a/tests/mode.test.ts
+++ b/tests/mode.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for mode.ts — nerf_mode tool handler.
+ *
+ * Tests use real filesystem operations with temp config files.
+ * No mocking of internal modules.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync } from "node:fs";
+import {
+  configPath,
+  readConfig,
+  writeConfig,
+  DEFAULTS,
+  MODE_MAP,
+  type NerfConfig,
+} from "../config.ts";
+import { handleMode } from "../mode.ts";
+
+describe("nerf_mode", () => {
+  let testSessionId: string;
+
+  beforeEach(() => {
+    testSessionId = `test-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    // Set env so resolveSessionId() returns our test session ID
+    process.env.CLAUDE_SESSION_ID = testSessionId;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const path = configPath(testSessionId);
+    try { rmSync(path, { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
+  });
+
+  test("mode returns current mode when no arg provided", async () => {
+    // Default mode is hurt-me-plenty
+    const result = await handleMode({});
+
+    expect(result).toContain("Current mode: hurt-me-plenty");
+    expect(result).toContain("prompted crystallization");
+    expect(result).toContain("CRYSTALLIZE_MODE: prompt");
+  });
+
+  test("mode returns current mode from existing config", async () => {
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const result = await handleMode({});
+
+    expect(result).toContain("Current mode: ultraviolence");
+    expect(result).toContain("auto-crystallize");
+    expect(result).toContain("CRYSTALLIZE_MODE: yolo");
+  });
+
+  test("mode sets valid mode — ultraviolence", async () => {
+    const result = await handleMode({ mode: "ultraviolence" });
+
+    expect(result).toContain("Mode set: ultraviolence");
+    expect(result).toContain("auto-crystallize");
+    expect(result).toContain("CRYSTALLIZE_MODE: yolo");
+
+    // Verify config was actually written
+    const config = readConfig(testSessionId);
+    expect(config.mode).toBe("ultraviolence");
+  });
+
+  test("mode sets valid mode — not-too-rough", async () => {
+    const result = await handleMode({ mode: "not-too-rough" });
+
+    expect(result).toContain("Mode set: not-too-rough");
+    expect(result).toContain("manual crystallization");
+    expect(result).toContain("CRYSTALLIZE_MODE: manual");
+
+    const config = readConfig(testSessionId);
+    expect(config.mode).toBe("not-too-rough");
+  });
+
+  test("mode sets valid mode — hurt-me-plenty", async () => {
+    // First set to something else
+    writeConfig(testSessionId, {
+      ...DEFAULTS,
+      mode: "ultraviolence",
+      session_id: testSessionId,
+    });
+
+    const result = await handleMode({ mode: "hurt-me-plenty" });
+
+    expect(result).toContain("Mode set: hurt-me-plenty");
+    expect(result).toContain("CRYSTALLIZE_MODE: prompt");
+
+    const config = readConfig(testSessionId);
+    expect(config.mode).toBe("hurt-me-plenty");
+  });
+
+  test("mode rejects invalid mode with error message", async () => {
+    const result = await handleMode({ mode: "nightmare" });
+
+    expect(result).toContain('Invalid mode: "nightmare"');
+    expect(result).toContain("Valid modes:");
+    expect(result).toContain("not-too-rough");
+    expect(result).toContain("hurt-me-plenty");
+    expect(result).toContain("ultraviolence");
+  });
+
+  test("mode rejects empty string as mode", async () => {
+    const result = await handleMode({ mode: "" });
+
+    expect(result).toContain("Invalid mode:");
+  });
+
+  test("mode maps correctly to CRYSTALLIZE_MODE", async () => {
+    // Test each mode maps to the right crystallizer mode
+    for (const [doom, crystallizer] of Object.entries(MODE_MAP)) {
+      const result = await handleMode({ mode: doom });
+      expect(result).toContain(`CRYSTALLIZE_MODE: ${crystallizer}`);
+    }
+  });
+
+  test("mode preserves existing dart config when setting mode", async () => {
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 80_000, hard: 100_000, ouch: 150_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    await handleMode({ mode: "ultraviolence" });
+
+    const updated = readConfig(testSessionId);
+    expect(updated.mode).toBe("ultraviolence");
+    // Darts should be preserved
+    expect(updated.darts.soft).toBe(80_000);
+    expect(updated.darts.hard).toBe(100_000);
+    expect(updated.darts.ouch).toBe(150_000);
+  });
+});

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for status.ts — nerf_status tool handler.
+ *
+ * Tests use real filesystem operations with temp config files.
+ * No mocking of internal modules.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync, writeFileSync } from "node:fs";
+import { configPath, writeConfig, DEFAULTS, type NerfConfig } from "../config.ts";
+import { handleStatus, formatTokenCount } from "../status.ts";
+
+describe("nerf_status", () => {
+  let testSessionId: string;
+
+  beforeEach(() => {
+    testSessionId = `test-status-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    // Set env so resolveSessionId() returns our test session ID
+    process.env.CLAUDE_SESSION_ID = testSessionId;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const path = configPath(testSessionId);
+    try { rmSync(path, { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
+  });
+
+  test("status returns formatted output with known config", async () => {
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 100_000, hard: 130_000, ouch: 180_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const result = await handleStatus({});
+
+    expect(result).toContain("nerf — ultraviolence");
+    expect(result).toContain("auto-crystallize");
+    expect(result).toContain("Darts:");
+    expect(result).toContain("soft   100k   warning");
+    expect(result).toContain("hard   130k   crystallize");
+    expect(result).toContain("ouch   180k   compact or die");
+  });
+
+  test("status shows defaults when no config exists", async () => {
+    // No config file written — should use defaults
+    const result = await handleStatus({});
+
+    expect(result).toContain("nerf — hurt-me-plenty");
+    expect(result).toContain("prompted crystallization");
+    expect(result).toContain("soft   120k   warning");
+    expect(result).toContain("hard   150k   crystallize");
+    expect(result).toContain("ouch   200k   compact or die");
+  });
+
+  test("status includes context usage as unavailable when module missing", async () => {
+    // context.ts doesn't exist yet (#223), so usage should be unavailable
+    const result = await handleStatus({});
+
+    expect(result).toContain("Context: unavailable");
+  });
+
+  test("status output format matches spec", async () => {
+    const config: NerfConfig = {
+      mode: "not-too-rough",
+      darts: { soft: 80_000, hard: 100_000, ouch: 150_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const result = await handleStatus({});
+    const lines = result.split("\n");
+
+    // First line: mode header
+    expect(lines[0]).toMatch(/^nerf — not-too-rough \(/);
+    // Empty separator line
+    expect(lines[1]).toBe("");
+    // Darts header
+    expect(lines[2]).toBe("Darts:");
+    // Dart lines
+    expect(lines[3]).toContain("soft");
+    expect(lines[4]).toContain("hard");
+    expect(lines[5]).toContain("ouch");
+    // Empty separator
+    expect(lines[6]).toBe("");
+    // Context line
+    expect(lines[7]).toMatch(/^Context:/);
+  });
+});
+
+describe("formatTokenCount", () => {
+  test("formats large numbers with k suffix", () => {
+    expect(formatTokenCount(120_000)).toBe("120k");
+    expect(formatTokenCount(150_000)).toBe("150k");
+    expect(formatTokenCount(200_000)).toBe("200k");
+  });
+
+  test("rounds to nearest k", () => {
+    expect(formatTokenCount(120_500)).toBe("121k");
+    expect(formatTokenCount(99_499)).toBe("99k");
+    expect(formatTokenCount(1_000)).toBe("1k");
+  });
+
+  test("handles zero", () => {
+    expect(formatTokenCount(0)).toBe("0k");
+  });
+});


### PR DESCRIPTION
## Summary

Replace nerf_status and nerf_mode stubs with real handler implementations. Status displays mode, dart thresholds, and context usage in human-readable format. Mode validates and persists behavior mode with CRYSTALLIZE_MODE mapping.

## Changes

- `status.ts` — `handleStatus()` with formatted output, context usage integration, statusline indicators
- `mode.ts` — `handleMode()` with get/set, validation, CRYSTALLIZE_MODE mapping
- `index.ts` — Replaced nerf_status/nerf_mode stubs with real handler imports
- `tests/status.test.ts` — 7 tests for status display, defaults, format spec
- `tests/mode.test.ts` — 9 tests for get/set/reject/mapping/preserve

## Test Results

40 tests pass (24 prior + 16 new)

Closes #220

Generated with [Claude Code](https://claude.com/claude-code)