### PR TITLE
feat(tools): nerf_darts + nerf_budget tool handlers

### DIFF
--- a/budget.ts
+++ b/budget.ts
@@ -1,0 +1,53 @@
+/**
+ * nerf_budget tool handler.
+ *
+ * Sets the ouch dart and computes proportional soft/hard thresholds.
+ * soft = floor(ouch * 0.60), hard = floor(ouch * 0.75).
+ */
+
+import { readConfig, writeConfig, type NerfConfig } from "./config.ts";
+import { resolveSessionId } from "./session.ts";
+import { formatTokenCount } from "./status.ts";
+
+/**
+ * Handle the nerf_budget tool call.
+ *
+ * Requires `ouch` parameter. Computes soft and hard proportionally,
+ * writes all three darts to config, returns new positions.
+ */
+export async function handleBudget(
+  params: Record<string, unknown>,
+): Promise<string> {
+  const sessionId = resolveSessionId();
+  const config = readConfig(sessionId);
+
+  const ouch = params.ouch as number | undefined;
+
+  // Validate ouch is provided
+  if (ouch === undefined) {
+    return "Error: ouch parameter is required";
+  }
+
+  // Validate positive integer
+  if (!Number.isInteger(ouch) || ouch <= 0) {
+    return `Error: ouch must be a positive integer, got ${ouch}`;
+  }
+
+  // Compute proportional darts
+  const soft = Math.floor(ouch * 0.60);
+  const hard = Math.floor(ouch * 0.75);
+
+  // Write to config
+  const newConfig: NerfConfig = {
+    ...config,
+    darts: { soft, hard, ouch },
+  };
+  writeConfig(sessionId, newConfig);
+
+  return [
+    "Budget set:",
+    `  soft   ${formatTokenCount(soft)}   warning (60%)`,
+    `  hard   ${formatTokenCount(hard)}   crystallize (75%)`,
+    `  ouch   ${formatTokenCount(ouch)}   compact or die`,
+  ].join("\n");
+}

--- a/darts.ts
+++ b/darts.ts
@@ -1,0 +1,79 @@
+/**
+ * nerf_darts tool handler.
+ *
+ * Gets or sets individual dart thresholds (soft, hard, ouch).
+ * All-or-nothing: must provide all three or none.
+ * Validates soft < hard < ouch, all positive integers.
+ */
+
+import { readConfig, writeConfig, type NerfConfig } from "./config.ts";
+import { resolveSessionId } from "./session.ts";
+import { formatTokenCount } from "./status.ts";
+
+/**
+ * Handle the nerf_darts tool call.
+ *
+ * - No args: return current dart positions with labels
+ * - With args: validate all-or-nothing, ordering, positivity. Write to config.
+ */
+export async function handleDarts(
+  params: Record<string, unknown>,
+): Promise<string> {
+  const sessionId = resolveSessionId();
+  const config = readConfig(sessionId);
+
+  const soft = params.soft as number | undefined;
+  const hard = params.hard as number | undefined;
+  const ouch = params.ouch as number | undefined;
+
+  // No args — return current positions
+  if (soft === undefined && hard === undefined && ouch === undefined) {
+    return formatDarts(config);
+  }
+
+  // Partial args — reject
+  if (soft === undefined || hard === undefined || ouch === undefined) {
+    return "Error: must provide all three darts (soft, hard, ouch) or none. Partial updates are not allowed.";
+  }
+
+  // Validate positive integers
+  if (!Number.isInteger(soft) || soft <= 0) {
+    return `Error: soft must be a positive integer, got ${soft}`;
+  }
+  if (!Number.isInteger(hard) || hard <= 0) {
+    return `Error: hard must be a positive integer, got ${hard}`;
+  }
+  if (!Number.isInteger(ouch) || ouch <= 0) {
+    return `Error: ouch must be a positive integer, got ${ouch}`;
+  }
+
+  // Validate ordering: soft < hard < ouch
+  if (soft >= hard) {
+    return `Error: soft (${soft}) must be less than hard (${hard})`;
+  }
+  if (hard >= ouch) {
+    return `Error: hard (${hard}) must be less than ouch (${ouch})`;
+  }
+
+  // Write to config
+  const newConfig: NerfConfig = {
+    ...config,
+    darts: { soft, hard, ouch },
+  };
+  writeConfig(sessionId, newConfig);
+
+  return formatDarts(newConfig);
+}
+
+/**
+ * Format dart positions for display.
+ */
+function formatDarts(config: NerfConfig): string {
+  const { soft, hard, ouch } = config.darts;
+  return [
+    "Darts:",
+    `  soft   ${formatTokenCount(soft)}   warning`,
+    `  hard   ${formatTokenCount(hard)}   crystallize`,
+    `  ouch   ${formatTokenCount(ouch)}   compact or die`,
+  ].join("\n");
+}

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,8 @@ import {
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { handleStatus } from "./status.ts";
 import { handleMode } from "./mode.ts";
+import { handleDarts } from "./darts.ts";
+import { handleBudget } from "./budget.ts";
 
 /**
  * Tool schemas for the nerf MCP server.
@@ -101,8 +103,8 @@ const HANDLERS: Record<
 > = {
   nerf_status: async (params) => handleStatus(params),
   nerf_mode: async (params) => handleMode(params),
-  nerf_darts: async () => "not implemented",
-  nerf_budget: async () => "not implemented",
+  nerf_darts: async (params) => handleDarts(params),
+  nerf_budget: async (params) => handleBudget(params),
   nerf_scope: async () => "not implemented",
 };
 

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for budget.ts — nerf_budget tool handler.
+ *
+ * Tests use real filesystem operations with temp config files.
+ * No mocking of internal modules.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync } from "node:fs";
+import {
+  configPath,
+  readConfig,
+  writeConfig,
+  DEFAULTS,
+  type NerfConfig,
+} from "../config.ts";
+import { handleBudget } from "../budget.ts";
+
+describe("nerf_budget", () => {
+  let testSessionId: string;
+
+  beforeEach(() => {
+    testSessionId = `test-budget-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    process.env.CLAUDE_SESSION_ID = testSessionId;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const path = configPath(testSessionId);
+    try { rmSync(path, { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
+  });
+
+  test("budget computes proportional darts", async () => {
+    const result = await handleBudget({ ouch: 200_000 });
+
+    // soft = floor(200000 * 0.60) = 120000
+    // hard = floor(200000 * 0.75) = 150000
+    expect(result).toContain("Budget set:");
+    expect(result).toContain("soft   120k");
+    expect(result).toContain("hard   150k");
+    expect(result).toContain("ouch   200k");
+  });
+
+  test("budget writes config", async () => {
+    await handleBudget({ ouch: 200_000 });
+
+    const config = readConfig(testSessionId);
+    expect(config.darts.soft).toBe(120_000);
+    expect(config.darts.hard).toBe(150_000);
+    expect(config.darts.ouch).toBe(200_000);
+  });
+
+  test("budget uses Math.floor for non-round values", async () => {
+    // 170_000 * 0.60 = 102_000 (exact)
+    // 170_000 * 0.75 = 127_500 → floor = 127_500 (exact)
+    await handleBudget({ ouch: 170_000 });
+
+    const config = readConfig(testSessionId);
+    expect(config.darts.soft).toBe(102_000);
+    expect(config.darts.hard).toBe(127_500);
+    expect(config.darts.ouch).toBe(170_000);
+  });
+
+  test("budget uses Math.floor for values producing fractions", async () => {
+    // 133_333 * 0.60 = 79_999.8 → floor = 79_999
+    // 133_333 * 0.75 = 99_999.75 → floor = 99_999
+    await handleBudget({ ouch: 133_333 });
+
+    const config = readConfig(testSessionId);
+    expect(config.darts.soft).toBe(79_999);
+    expect(config.darts.hard).toBe(99_999);
+    expect(config.darts.ouch).toBe(133_333);
+  });
+
+  test("budget rejects zero", async () => {
+    const result = await handleBudget({ ouch: 0 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("budget rejects negative values", async () => {
+    const result = await handleBudget({ ouch: -100_000 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("budget rejects non-integer values", async () => {
+    const result = await handleBudget({ ouch: 200_000.5 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("budget rejects missing ouch parameter", async () => {
+    const result = await handleBudget({});
+
+    expect(result).toContain("Error");
+    expect(result).toContain("ouch");
+  });
+
+  test("budget preserves mode when setting thresholds", async () => {
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    await handleBudget({ ouch: 180_000 });
+
+    const updated = readConfig(testSessionId);
+    expect(updated.mode).toBe("ultraviolence");
+    // Darts should be updated proportionally
+    expect(updated.darts.soft).toBe(Math.floor(180_000 * 0.60));
+    expect(updated.darts.hard).toBe(Math.floor(180_000 * 0.75));
+    expect(updated.darts.ouch).toBe(180_000);
+  });
+
+  test("budget display includes percentage labels", async () => {
+    const result = await handleBudget({ ouch: 200_000 });
+
+    expect(result).toContain("60%");
+    expect(result).toContain("75%");
+  });
+});

--- a/tests/darts.test.ts
+++ b/tests/darts.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for darts.ts — nerf_darts tool handler.
+ *
+ * Tests use real filesystem operations with temp config files.
+ * No mocking of internal modules.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync } from "node:fs";
+import {
+  configPath,
+  readConfig,
+  writeConfig,
+  DEFAULTS,
+  type NerfConfig,
+} from "../config.ts";
+import { handleDarts } from "../darts.ts";
+
+describe("nerf_darts", () => {
+  let testSessionId: string;
+
+  beforeEach(() => {
+    testSessionId = `test-darts-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    process.env.CLAUDE_SESSION_ID = testSessionId;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const path = configPath(testSessionId);
+    try { rmSync(path, { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
+  });
+
+  test("darts returns current positions", async () => {
+    const result = await handleDarts({});
+
+    expect(result).toContain("Darts:");
+    expect(result).toContain("soft   120k   warning");
+    expect(result).toContain("hard   150k   crystallize");
+    expect(result).toContain("ouch   200k   compact or die");
+  });
+
+  test("darts returns current positions from existing config", async () => {
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 80_000, hard: 100_000, ouch: 150_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const result = await handleDarts({});
+
+    expect(result).toContain("soft   80k   warning");
+    expect(result).toContain("hard   100k   crystallize");
+    expect(result).toContain("ouch   150k   compact or die");
+  });
+
+  test("darts sets valid thresholds", async () => {
+    const result = await handleDarts({
+      soft: 90_000,
+      hard: 120_000,
+      ouch: 160_000,
+    });
+
+    expect(result).toContain("soft   90k   warning");
+    expect(result).toContain("hard   120k   crystallize");
+    expect(result).toContain("ouch   160k   compact or die");
+
+    // Verify config was actually written
+    const config = readConfig(testSessionId);
+    expect(config.darts.soft).toBe(90_000);
+    expect(config.darts.hard).toBe(120_000);
+    expect(config.darts.ouch).toBe(160_000);
+  });
+
+  test("darts rejects bad ordering — soft >= hard", async () => {
+    const result = await handleDarts({
+      soft: 150_000,
+      hard: 100_000,
+      ouch: 200_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("soft");
+    expect(result).toContain("hard");
+  });
+
+  test("darts rejects bad ordering — hard >= ouch", async () => {
+    const result = await handleDarts({
+      soft: 90_000,
+      hard: 200_000,
+      ouch: 150_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("hard");
+    expect(result).toContain("ouch");
+  });
+
+  test("darts rejects bad ordering — soft == hard", async () => {
+    const result = await handleDarts({
+      soft: 100_000,
+      hard: 100_000,
+      ouch: 200_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("soft");
+    expect(result).toContain("hard");
+  });
+
+  test("darts rejects negative values", async () => {
+    const result = await handleDarts({
+      soft: -1,
+      hard: 100_000,
+      ouch: 200_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("darts rejects zero values", async () => {
+    const result = await handleDarts({
+      soft: 0,
+      hard: 100_000,
+      ouch: 200_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("darts rejects partial args — only soft", async () => {
+    const result = await handleDarts({ soft: 100_000 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("all three");
+  });
+
+  test("darts rejects partial args — only soft and hard", async () => {
+    const result = await handleDarts({ soft: 100_000, hard: 150_000 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("all three");
+  });
+
+  test("darts rejects partial args — only ouch", async () => {
+    const result = await handleDarts({ ouch: 200_000 });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("all three");
+  });
+
+  test("darts rejects non-integer values", async () => {
+    const result = await handleDarts({
+      soft: 100_000.5,
+      hard: 150_000,
+      ouch: 200_000,
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("positive integer");
+  });
+
+  test("darts preserves mode when setting thresholds", async () => {
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    await handleDarts({
+      soft: 90_000,
+      hard: 120_000,
+      ouch: 160_000,
+    });
+
+    const updated = readConfig(testSessionId);
+    expect(updated.mode).toBe("ultraviolence");
+    expect(updated.darts.soft).toBe(90_000);
+  });
+});


### PR DESCRIPTION
## Summary

Replace nerf_darts and nerf_budget stubs with real handlers. Darts supports get/set with all-or-nothing validation (soft < hard < ouch, positive integers). Budget sets ouch and computes proportional soft (60%) and hard (75%) via Math.floor.

## Changes

- `darts.ts` — `handleDarts()` with all-or-nothing, ordering, positivity validation
- `budget.ts` — `handleBudget()` with proportional scaling (60%/75%)
- `index.ts` — Replaced nerf_darts/nerf_budget stubs with real handler imports
- `tests/darts.test.ts` — 12 tests
- `tests/budget.test.ts` — 10 tests

## Test Results

67 tests pass (45 prior + 22 new)

Closes #221

Generated with [Claude Code](https://claude.com/claude-code)