### PR TITLE
feat(statusline): context pressure indicator lifecycle

### DIFF
--- a/budget.ts
+++ b/budget.ts
@@ -8,6 +8,7 @@
 import { readConfig, writeConfig, type NerfConfig } from "./config.ts";
 import { resolveSessionId } from "./session.ts";
 import { formatTokenCount } from "./status.ts";
+import { updateStatuslineIndicator } from "./indicator.ts";
 
 /**
  * Handle the nerf_budget tool call.
@@ -43,6 +44,7 @@ export async function handleBudget(
     darts: { soft, hard, ouch },
   };
   writeConfig(sessionId, newConfig);
+  await updateStatuslineIndicator(sessionId, newConfig);
 
   return [
     "Budget set:",

--- a/darts.ts
+++ b/darts.ts
@@ -9,6 +9,7 @@
 import { readConfig, writeConfig, type NerfConfig } from "./config.ts";
 import { resolveSessionId } from "./session.ts";
 import { formatTokenCount } from "./status.ts";
+import { updateStatuslineIndicator } from "./indicator.ts";
 
 /**
  * Handle the nerf_darts tool call.
@@ -61,6 +62,7 @@ export async function handleDarts(
     darts: { soft, hard, ouch },
   };
   writeConfig(sessionId, newConfig);
+  await updateStatuslineIndicator(sessionId, newConfig);
 
   return formatDarts(newConfig);
 }

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ import { handleMode } from "./mode.ts";
 import { handleDarts } from "./darts.ts";
 import { handleBudget } from "./budget.ts";
 import { handleScope } from "./scope.ts";
+import { removeIndicator } from "./statusline.ts";
+import { NERF_INDICATOR_PREFIX } from "./indicator.ts";
 
 /**
  * Tool schemas for the nerf MCP server.
@@ -133,6 +135,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   return {
     content: [{ type: "text" as const, text: result }],
   };
+});
+
+// Clean up nerf indicator from statusline on process exit
+process.on("SIGTERM", () => {
+  try { removeIndicator(NERF_INDICATOR_PREFIX); } catch { /* best-effort cleanup */ }
+  process.exit(0);
+});
+process.on("SIGINT", () => {
+  try { removeIndicator(NERF_INDICATOR_PREFIX); } catch { /* best-effort cleanup */ }
+  process.exit(0);
 });
 
 const transport = new StdioServerTransport();

--- a/indicator.ts
+++ b/indicator.ts
@@ -1,0 +1,85 @@
+/**
+ * indicator.ts — Statusline indicator lifecycle module
+ *
+ * Computes context pressure indicators based on dart thresholds and pushes
+ * them to the shared statusline file. Indicators use the `nerf:` prefix
+ * for namespacing in the shared indicators array.
+ *
+ * Pure logic in computeIndicator(), side-effecting push in
+ * updateStatuslineIndicator().
+ */
+
+import { getContextUsage, type ContextUsage } from "./context.ts";
+import { type NerfConfig } from "./config.ts";
+import { addIndicator, removeIndicator } from "./statusline.ts";
+
+/** Prefix for all nerf indicators in the shared statusline file. */
+export const NERF_INDICATOR_PREFIX = "nerf:";
+
+export interface IndicatorState {
+  level: "none" | "soft" | "hard" | "critical";
+  text: string;
+}
+
+/**
+ * Pure function: compute the indicator level and display text from context
+ * usage and dart configuration.
+ *
+ * Thresholds (checked highest-first):
+ *   usage.total >= ouch  -> critical  🚨
+ *   usage.total >= hard  -> hard      🔶
+ *   usage.total >= soft  -> soft      ⚡
+ *   otherwise            -> none      (no indicator)
+ *
+ * Percentage is taken directly from context-analyzer output (usage.percent),
+ * rounded to the nearest integer.
+ */
+export function computeIndicator(
+  usage: ContextUsage | null,
+  config: NerfConfig,
+): IndicatorState {
+  if (!usage) return { level: "none", text: "" };
+
+  const pct = Math.round(usage.percent);
+
+  if (usage.total >= config.darts.ouch) {
+    return { level: "critical", text: `\u{1F6A8} ${pct}%` };
+  }
+  if (usage.total >= config.darts.hard) {
+    return { level: "hard", text: `\u{1F536} ${pct}%` };
+  }
+  if (usage.total >= config.darts.soft) {
+    return { level: "soft", text: `\u{26A1} ${pct}%` };
+  }
+
+  return { level: "none", text: "" };
+}
+
+/**
+ * Async side-effecting function: fetch current context usage, compute the
+ * indicator, then atomically update the shared statusline file.
+ *
+ * 1. Calls getContextUsage(sessionId) from context.ts
+ * 2. Calls computeIndicator() for pure threshold logic
+ * 3. Removes any existing `nerf:` prefixed indicator (prefix-based cleanup)
+ * 4. Adds the new indicator if level !== "none"
+ *
+ * Returns the computed IndicatorState so callers can inspect it.
+ */
+export async function updateStatuslineIndicator(
+  sessionId: string,
+  config: NerfConfig,
+): Promise<IndicatorState> {
+  const usage = await getContextUsage(sessionId);
+  const state = computeIndicator(usage, config);
+
+  // Remove any existing nerf indicator first (prefix match)
+  removeIndicator(NERF_INDICATOR_PREFIX);
+
+  // Add new indicator if above soft threshold
+  if (state.level !== "none") {
+    addIndicator(`${NERF_INDICATOR_PREFIX}${state.text}`);
+  }
+
+  return state;
+}

--- a/mode.ts
+++ b/mode.ts
@@ -12,6 +12,7 @@ import {
   type NerfConfig,
 } from "./config.ts";
 import { resolveSessionId } from "./session.ts";
+import { updateStatuslineIndicator } from "./indicator.ts";
 
 const VALID_MODES: NerfConfig["mode"][] = [
   "not-too-rough",
@@ -64,6 +65,7 @@ export async function handleMode(
     mode: requestedMode as NerfConfig["mode"],
   };
   writeConfig(sessionId, newConfig);
+  await updateStatuslineIndicator(sessionId, newConfig);
 
   const description = MODE_DESCRIPTIONS[requestedMode] ?? "unknown mode";
   const crystallizerMode = MODE_MAP[requestedMode] ?? "unknown";

--- a/status.ts
+++ b/status.ts
@@ -7,39 +7,15 @@
 
 import { readConfig, MODE_MAP, type NerfConfig } from "./config.ts";
 import { resolveSessionId } from "./session.ts";
-import { addIndicator, removeIndicator } from "./statusline.ts";
+import { getContextUsage } from "./context.ts";
+import { updateStatuslineIndicator } from "./indicator.ts";
 
 /**
  * Format a token count for human-readable display.
- * e.g., 120000 → "120k", 1500 → "2k", 200000 → "200k"
+ * e.g., 120000 -> "120k", 1500 -> "2k", 200000 -> "200k"
  */
 export function formatTokenCount(value: number): string {
   return Math.round(value / 1000) + "k";
-}
-
-/**
- * Attempt to get context usage. Returns null if the context module
- * is not available (#223 may not be merged yet).
- *
- * Uses a runtime-only path string to avoid TypeScript compile-time errors
- * when context.ts does not exist.
- */
-async function getContextUsage(): Promise<{
-  used: number;
-  total: number;
-} | null> {
-  try {
-    // Build the path at runtime so tsc doesn't resolve it at compile time
-    const contextModule = "./context" + ".ts";
-    const mod = await import(/* @vite-ignore */ contextModule);
-    if (typeof mod.getContextUsage === "function") {
-      const result = mod.getContextUsage();
-      return result ?? null;
-    }
-  } catch {
-    // context.ts not available — #223 not merged yet
-  }
-  return null;
 }
 
 /**
@@ -50,38 +26,6 @@ const MODE_DESCRIPTIONS: Record<string, string> = {
   "hurt-me-plenty": "prompted crystallization — reminders at thresholds",
   ultraviolence: "auto-crystallize — yolo mode, saves state automatically",
 };
-
-/**
- * Update statusline indicator based on context usage level.
- * Removes any existing nerf context indicator first, then adds the
- * appropriate one (if any).
- */
-function updateStatuslineIndicator(
-  contextUsage: { used: number; total: number } | null,
-  config: NerfConfig,
-): void {
-  // Remove any existing nerf context indicators
-  removeIndicator("⚡");
-  removeIndicator("🔶");
-  removeIndicator("🚨");
-
-  if (!contextUsage) return;
-
-  const { used } = contextUsage;
-  const { soft, hard, ouch } = config.darts;
-
-  if (used >= ouch * 0.85) {
-    const pct = Math.round((used / ouch) * 100);
-    addIndicator(`🚨 ${pct}%`);
-  } else if (used >= hard) {
-    const pct = Math.round((used / ouch) * 100);
-    addIndicator(`🔶 ${pct}%`);
-  } else if (used >= soft) {
-    const pct = Math.round((used / ouch) * 100);
-    addIndicator(`⚡ ${pct}%`);
-  }
-  // Below soft: no indicator (no clutter when healthy)
-}
 
 /**
  * Handle the nerf_status tool call.
@@ -95,10 +39,11 @@ export async function handleStatus(
   const modeDescription =
     MODE_DESCRIPTIONS[modeName] ?? "unknown mode";
 
-  const contextUsage = await getContextUsage();
+  // Fetch context usage for display
+  const contextUsage = await getContextUsage(sessionId);
 
-  // Update statusline indicator
-  updateStatuslineIndicator(contextUsage, config);
+  // Update statusline indicator (side-effect)
+  await updateStatuslineIndicator(sessionId, config);
 
   // Format dart values
   const softStr = formatTokenCount(config.darts.soft);
@@ -108,8 +53,8 @@ export async function handleStatus(
   // Format context line
   let contextLine: string;
   if (contextUsage) {
-    const pct = Math.round((contextUsage.used / config.darts.ouch) * 100);
-    contextLine = `Context: ${formatTokenCount(contextUsage.used)}/${ouchStr} (${pct}%)`;
+    const pct = Math.round(contextUsage.percent);
+    contextLine = `Context: ${formatTokenCount(contextUsage.total)}/${ouchStr} (${pct}%)`;
   } else {
     contextLine = "Context: unavailable";
   }

--- a/tests/indicator.test.ts
+++ b/tests/indicator.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for indicator.ts — Statusline indicator lifecycle module
+ *
+ * Tests 1-6: Pure function tests for computeIndicator() — no mocking needed.
+ * Tests 7-8: Integration tests for updateStatuslineIndicator() — use a real
+ *   temp statusline file, fake analyzer script, and fake transcript.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { createHash } from "node:crypto";
+import { execSync } from "node:child_process";
+import { computeIndicator, updateStatuslineIndicator, NERF_INDICATOR_PREFIX } from "../indicator.ts";
+import { resolveProjectRoot, addIndicatorToFile } from "../statusline.ts";
+import type { NerfConfig } from "../config.ts";
+
+/**
+ * Build a NerfConfig with the given dart positions.
+ */
+function makeConfig(
+  soft: number,
+  hard: number,
+  ouch: number,
+): NerfConfig {
+  return {
+    mode: "hurt-me-plenty",
+    darts: { soft, hard, ouch },
+    session_id: "test",
+  };
+}
+
+describe("computeIndicator", () => {
+  const config = makeConfig(120_000, 150_000, 200_000);
+
+  test("returns none when usage is below soft dart", () => {
+    const usage = { total: 100_000, limit: 200_000, percent: 50.0 };
+    const result = computeIndicator(usage, config);
+
+    expect(result.level).toBe("none");
+    expect(result.text).toBe("");
+  });
+
+  test("returns soft level with lightning emoji at soft threshold", () => {
+    const usage = { total: 120_000, limit: 200_000, percent: 60.0 };
+    const result = computeIndicator(usage, config);
+
+    expect(result.level).toBe("soft");
+    expect(result.text).toContain("\u{26A1}");
+    expect(result.text).toContain("60%");
+  });
+
+  test("returns hard level with diamond emoji at hard threshold", () => {
+    const usage = { total: 150_000, limit: 200_000, percent: 75.0 };
+    const result = computeIndicator(usage, config);
+
+    expect(result.level).toBe("hard");
+    expect(result.text).toContain("\u{1F536}");
+    expect(result.text).toContain("75%");
+  });
+
+  test("returns critical level with siren emoji at ouch threshold", () => {
+    const usage = { total: 200_000, limit: 200_000, percent: 100.0 };
+    const result = computeIndicator(usage, config);
+
+    expect(result.level).toBe("critical");
+    expect(result.text).toContain("\u{1F6A8}");
+    expect(result.text).toContain("100%");
+  });
+
+  test("returns none when usage is null", () => {
+    const result = computeIndicator(null, config);
+
+    expect(result.level).toBe("none");
+    expect(result.text).toBe("");
+  });
+
+  test("rounds percentage correctly", () => {
+    // 62.4% should round to 62, 62.5% should round to 63
+    const usage1 = { total: 130_000, limit: 200_000, percent: 62.4 };
+    const result1 = computeIndicator(usage1, config);
+    expect(result1.text).toContain("62%");
+
+    const usage2 = { total: 130_000, limit: 200_000, percent: 62.5 };
+    const result2 = computeIndicator(usage2, config);
+    expect(result2.text).toContain("63%");
+
+    // Edge case: 99.7% rounds to 100
+    const usage3 = { total: 200_000, limit: 200_000, percent: 99.7 };
+    const result3 = computeIndicator(usage3, config);
+    expect(result3.text).toContain("100%");
+  });
+});
+
+describe("updateStatuslineIndicator", () => {
+  let tempDir: string;
+  let fakeProjectDir: string;
+  let originalEnv: Record<string, string | undefined>;
+  let agentFile: string;
+  let originalAgentContent: string | null = null;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "nerf-indicator-test-"));
+    originalEnv = {
+      NERF_ANALYZER_PATH: process.env.NERF_ANALYZER_PATH,
+      CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+    };
+
+    // Set up agent identity file so statusline helpers resolve to a known path
+    const projectRoot = resolveProjectRoot();
+    const dirHash = createHash("md5").update(projectRoot).digest("hex");
+    agentFile = `/tmp/claude-agent-${dirHash}.json`;
+
+    // Preserve existing agent file
+    try {
+      originalAgentContent = readFileSync(agentFile, "utf-8");
+    } catch {
+      originalAgentContent = null;
+    }
+
+    // Write test agent file with a unique dev name for this test
+    const testDevName = `indicator-test-${Date.now()}`;
+    writeFileSync(
+      agentFile,
+      JSON.stringify({
+        dev_name: testDevName,
+        dev_avatar: "\u{1F9EA}",
+        dev_team: "test",
+      }),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env.NERF_ANALYZER_PATH = originalEnv.NERF_ANALYZER_PATH;
+    process.env.CLAUDE_SESSION_ID = originalEnv.CLAUDE_SESSION_ID;
+
+    // Restore agent file
+    if (originalAgentContent !== null) {
+      writeFileSync(agentFile, originalAgentContent, "utf-8");
+    } else {
+      try { rmSync(agentFile, { force: true }); } catch { /* ignore */ }
+    }
+
+    // Clean up temp directory
+    rmSync(tempDir, { recursive: true, force: true });
+
+    // Clean up fake project dir
+    if (fakeProjectDir) {
+      try { rmSync(fakeProjectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+
+    // Clean up statusline file (resolve from current agent file)
+    try {
+      const raw = readFileSync(agentFile, "utf-8");
+      const data = JSON.parse(raw) as { dev_name?: string };
+      if (data.dev_name) {
+        const statusFile = `/tmp/claude-statusline-${data.dev_name}.json`;
+        rmSync(statusFile, { force: true });
+      }
+    } catch { /* ignore */ }
+  });
+
+  /**
+   * Helper: create a fake analyzer script and transcript so
+   * getContextUsage() returns known values.
+   */
+  function setupFakeAnalyzer(
+    sessionId: string,
+    total: number,
+    limit: number,
+    percent: number,
+  ): void {
+    const fakeAnalyzer = join(tempDir, "fake-analyzer.sh");
+    writeFileSync(
+      fakeAnalyzer,
+      `#!/bin/bash
+analyze_context() {
+  cat <<'ENDJSON'
+{
+  "tokens": { "total": ${total} },
+  "limit": ${limit},
+  "percent": ${percent}
+}
+ENDJSON
+}
+`,
+    );
+    chmodSync(fakeAnalyzer, 0o755);
+    process.env.NERF_ANALYZER_PATH = fakeAnalyzer;
+
+    // Create a fake transcript at the expected location
+    const projectsDir = join(homedir(), ".claude", "projects");
+    fakeProjectDir = join(projectsDir, `-tmp-nerf-indicator-test-${Date.now()}`);
+    mkdirSync(fakeProjectDir, { recursive: true });
+    writeFileSync(
+      join(fakeProjectDir, `${sessionId}.jsonl`),
+      '{"type":"assistant"}\n',
+    );
+
+    process.env.CLAUDE_SESSION_ID = sessionId;
+  }
+
+  /**
+   * Helper: read the statusline file for the current test agent.
+   */
+  function readStatuslineIndicators(): string[] {
+    try {
+      const raw = readFileSync(agentFile, "utf-8");
+      const agentData = JSON.parse(raw) as { dev_name?: string };
+      if (!agentData.dev_name) return [];
+      const statusFile = `/tmp/claude-statusline-${agentData.dev_name}.json`;
+      const statusRaw = readFileSync(statusFile, "utf-8");
+      const statusData = JSON.parse(statusRaw) as { indicators?: string[] };
+      return statusData.indicators ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  test("removes old nerf indicator before adding new one", async () => {
+    const sessionId = `indicator-removal-test-${Date.now()}`;
+    const config = makeConfig(120_000, 150_000, 200_000);
+
+    // Set up analyzer to return usage at soft level
+    setupFakeAnalyzer(sessionId, 130_000, 200_000, 65.0);
+
+    // First call: should add soft indicator
+    const state1 = await updateStatuslineIndicator(sessionId, config);
+    expect(state1.level).toBe("soft");
+
+    let indicators = readStatuslineIndicators();
+    const nerfIndicators1 = indicators.filter((i) => i.startsWith(NERF_INDICATOR_PREFIX));
+    expect(nerfIndicators1).toHaveLength(1);
+    expect(nerfIndicators1[0]).toContain("65%");
+
+    // Now change analyzer output to hard level and call again
+    setupFakeAnalyzer(sessionId, 160_000, 200_000, 80.0);
+    const state2 = await updateStatuslineIndicator(sessionId, config);
+    expect(state2.level).toBe("hard");
+
+    indicators = readStatuslineIndicators();
+    const nerfIndicators2 = indicators.filter((i) => i.startsWith(NERF_INDICATOR_PREFIX));
+    // Should have exactly ONE nerf indicator (old one removed)
+    expect(nerfIndicators2).toHaveLength(1);
+    expect(nerfIndicators2[0]).toContain("80%");
+  });
+
+  test("no indicator added when below soft threshold", async () => {
+    const sessionId = `indicator-healthy-test-${Date.now()}`;
+    const config = makeConfig(120_000, 150_000, 200_000);
+
+    // Set up analyzer to return usage below soft
+    setupFakeAnalyzer(sessionId, 80_000, 200_000, 40.0);
+
+    const state = await updateStatuslineIndicator(sessionId, config);
+    expect(state.level).toBe("none");
+    expect(state.text).toBe("");
+
+    const indicators = readStatuslineIndicators();
+    const nerfIndicators = indicators.filter((i) => i.startsWith(NERF_INDICATOR_PREFIX));
+    expect(nerfIndicators).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Extract inline indicator logic from `status.ts` into a dedicated `indicator.ts` module with `nerf:` prefix namespacing for statusline coexistence. Wire indicator updates into all config-changing handlers and add process cleanup.

## Changes

- **New:** `indicator.ts` — `computeIndicator()` (pure function), `updateStatuslineIndicator()` (async side-effect), `NERF_INDICATOR_PREFIX` constant
- **Refactored:** `status.ts` — removed 64 lines of inline indicator/context logic, now imports from `context.ts` and `indicator.ts`
- **Wired:** `mode.ts`, `darts.ts`, `budget.ts` — call `updateStatuslineIndicator()` after config writes
- **Added:** `index.ts` — SIGTERM/SIGINT cleanup handlers with try/catch
- **New:** `tests/indicator.test.ts` — 8 tests (6 pure function + 2 integration)

## Test Results

79 pass, 0 fail, 213 expect() calls across 10 files. Validation clean (TypeScript lint + shellcheck + tests).

Closes #224

Generated with [Claude Code](https://claude.com/claude-code)