### PR TITLE
feat(tools): add optional session_id parameter to all tool schemas

### DIFF
--- a/budget.ts
+++ b/budget.ts
@@ -19,7 +19,7 @@ import { updateStatuslineIndicator } from "./indicator.ts";
 export async function handleBudget(
   params: Record<string, unknown>,
 ): Promise<string> {
-  const sessionId = resolveSessionId();
+  const sessionId = resolveSessionId(params.session_id as string | undefined);
   const config = readConfig(sessionId);
 
   const ouch = params.ouch as number | undefined;

--- a/darts.ts
+++ b/darts.ts
@@ -20,7 +20,7 @@ import { updateStatuslineIndicator } from "./indicator.ts";
 export async function handleDarts(
   params: Record<string, unknown>,
 ): Promise<string> {
-  const sessionId = resolveSessionId();
+  const sessionId = resolveSessionId(params.session_id as string | undefined);
   const config = readConfig(sessionId);
 
   const soft = params.soft as number | undefined;

--- a/index.ts
+++ b/index.ts
@@ -15,10 +15,20 @@ import { removeIndicator } from "./statusline.ts";
 import { NERF_INDICATOR_PREFIX } from "./indicator.ts";
 
 /**
+ * Shared optional parameter included in every tool schema.
+ */
+const SESSION_ID_PROP = {
+  session_id: {
+    type: "string",
+    description: "Claude Code session ID. If omitted, resolved automatically.",
+  },
+} as const;
+
+/**
  * Tool schemas for the nerf MCP server.
  *
  * Each tool has a name, description, and inputSchema with typed parameters.
- * Handlers are stubs — actual logic comes in later issues (#220-#223).
+ * All tools accept an optional `session_id` for explicit session targeting.
  */
 export const TOOLS: Tool[] = [
   {
@@ -26,7 +36,7 @@ export const TOOLS: Tool[] = [
     description: "Show current mode, dart thresholds, and context usage",
     inputSchema: {
       type: "object" as const,
-      properties: {},
+      properties: { ...SESSION_ID_PROP },
     },
   },
   {
@@ -36,6 +46,7 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: "object" as const,
       properties: {
+        ...SESSION_ID_PROP,
         mode: {
           type: "string",
           enum: ["not-too-rough", "hurt-me-plenty", "ultraviolence"],
@@ -51,6 +62,7 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: "object" as const,
       properties: {
+        ...SESSION_ID_PROP,
         soft: {
           type: "number",
           description: "Soft dart threshold (token count)",
@@ -73,6 +85,7 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: "object" as const,
       properties: {
+        ...SESSION_ID_PROP,
         ouch: {
           type: "number",
           description: "The ouch (max) dart threshold to set",
@@ -87,6 +100,7 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: "object" as const,
       properties: {
+        ...SESSION_ID_PROP,
         interval: {
           type: "number",
           description: "Polling interval in milliseconds (default: 30000)",

--- a/mode.ts
+++ b/mode.ts
@@ -38,7 +38,7 @@ const MODE_DESCRIPTIONS: Record<string, string> = {
 export async function handleMode(
   params: Record<string, unknown>,
 ): Promise<string> {
-  const sessionId = resolveSessionId();
+  const sessionId = resolveSessionId(params.session_id as string | undefined);
   const config = readConfig(sessionId);
 
   const requestedMode = params.mode as string | undefined;

--- a/scope.ts
+++ b/scope.ts
@@ -6,6 +6,8 @@
  * process spawning that is complex enough to warrant its own issue.
  */
 
+import { resolveSessionId } from "./session.ts";
+
 /**
  * Handle the nerf_scope tool call.
  *
@@ -15,13 +17,14 @@
 export async function handleScope(
   params: Record<string, unknown>,
 ): Promise<string> {
+  const sessionId = resolveSessionId(params.session_id as string | undefined);
   const interval = params.interval as number | undefined;
 
   const lines = [
     "nerf_scope is not yet implemented in the MCP server.",
     "",
     "To monitor context usage, use the crystallizer's built-in tracking",
-    "or run: cc-context watch --session <session_id>",
+    `or run: cc-context watch --session ${sessionId}`,
   ];
 
   if (interval !== undefined) {

--- a/session.ts
+++ b/session.ts
@@ -16,7 +16,12 @@ import { createHash } from "node:crypto";
  * 2. Scan /tmp for claude session artifacts (transcript/output files)
  * 3. Fallback: generate a stable ID from PID + process start time
  */
-export function resolveSessionId(): string {
+export function resolveSessionId(override?: string): string {
+  // 0. Explicit override from tool params
+  if (override) {
+    return override;
+  }
+
   // 1. Direct env var
   const envId = process.env.CLAUDE_SESSION_ID;
   if (envId) {

--- a/status.ts
+++ b/status.ts
@@ -31,9 +31,9 @@ const MODE_DESCRIPTIONS: Record<string, string> = {
  * Handle the nerf_status tool call.
  */
 export async function handleStatus(
-  _params: Record<string, unknown>,
+  params: Record<string, unknown>,
 ): Promise<string> {
-  const sessionId = resolveSessionId();
+  const sessionId = resolveSessionId(params.session_id as string | undefined);
   const config = readConfig(sessionId);
   const modeName = config.mode;
   const modeDescription =

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -31,6 +31,22 @@ describe("nerf_budget", () => {
     try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
   });
 
+  test("budget uses explicit session_id param over env var", async () => {
+    const overrideId = `override-budget-${Date.now()}`;
+    delete process.env.CLAUDE_SESSION_ID;
+
+    const result = await handleBudget({ ouch: 100_000, session_id: overrideId });
+
+    expect(result).toContain("Budget set:");
+    expect(result).toContain("ouch   100k");
+
+    // Verify config was written to override session
+    const config = readConfig(overrideId);
+    expect(config.darts.ouch).toBe(100_000);
+
+    try { rmSync(configPath(overrideId), { force: true }); } catch { /* ignore */ }
+  });
+
   test("budget computes proportional darts", async () => {
     const result = await handleBudget({ ouch: 200_000 });
 

--- a/tests/darts.test.ts
+++ b/tests/darts.test.ts
@@ -31,6 +31,24 @@ describe("nerf_darts", () => {
     try { rmSync(`${path}.tmp`, { force: true }); } catch { /* ignore */ }
   });
 
+  test("darts uses explicit session_id param over env var", async () => {
+    const overrideId = `override-darts-${Date.now()}`;
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 50_000, hard: 75_000, ouch: 100_000 },
+      session_id: overrideId,
+    };
+    writeConfig(overrideId, config);
+
+    delete process.env.CLAUDE_SESSION_ID;
+    const result = await handleDarts({ session_id: overrideId });
+
+    expect(result).toContain("soft   50k   warning");
+    expect(result).toContain("ouch   100k   compact or die");
+
+    try { rmSync(configPath(overrideId), { force: true }); } catch { /* ignore */ }
+  });
+
   test("darts returns current positions", async () => {
     const result = await handleDarts({});
 

--- a/tests/mode.test.ts
+++ b/tests/mode.test.ts
@@ -42,6 +42,24 @@ describe("nerf_mode", () => {
     expect(result).toContain("CRYSTALLIZE_MODE: prompt");
   });
 
+  test("mode uses explicit session_id param over env var", async () => {
+    const overrideId = `override-mode-${Date.now()}`;
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: overrideId,
+    };
+    writeConfig(overrideId, config);
+
+    // Don't set env — pass session_id in params
+    delete process.env.CLAUDE_SESSION_ID;
+    const result = await handleMode({ session_id: overrideId });
+
+    expect(result).toContain("Current mode: ultraviolence");
+
+    try { rmSync(configPath(overrideId), { force: true }); } catch { /* ignore */ }
+  });
+
   test("mode returns current mode from existing config", async () => {
     const config: NerfConfig = {
       mode: "ultraviolence",

--- a/tests/scope.test.ts
+++ b/tests/scope.test.ts
@@ -27,6 +27,12 @@ describe("nerf_scope", () => {
     expect(result).toContain("will be used when the monitor is implemented");
   });
 
+  test("scope includes explicit session_id in help text", async () => {
+    const result = await handleScope({ session_id: "my-test-session-abc" });
+
+    expect(result).toContain("cc-context watch --session my-test-session-abc");
+  });
+
   test("scope without interval does not mention interval", async () => {
     const result = await handleScope({});
 

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -62,6 +62,25 @@ describe("nerf_status", () => {
     expect(result).toContain("Context: unavailable");
   });
 
+  test("status uses explicit session_id param over env var", async () => {
+    const overrideId = `override-status-${Date.now()}`;
+    // Write config to the override session, not the env session
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 50_000, hard: 75_000, ouch: 100_000 },
+      session_id: overrideId,
+    };
+    writeConfig(overrideId, config);
+
+    const result = await handleStatus({ session_id: overrideId });
+
+    expect(result).toContain("nerf — ultraviolence");
+    expect(result).toContain("ouch   100k   compact or die");
+
+    // Clean up
+    try { rmSync(configPath(overrideId), { force: true }); } catch { /* ignore */ }
+  });
+
   test("status output format matches spec", async () => {
     const config: NerfConfig = {
       mode: "not-too-rough",


### PR DESCRIPTION
## Summary

Add an optional `session_id` parameter to all 5 nerf tool schemas so the calling agent can pass its known session ID directly, enabling context usage tracking that was previously broken due to session ID resolution failures.

## Changes

- **`index.ts`** — `SESSION_ID_PROP` constant spread into all 5 tool schemas
- **`session.ts`** — `resolveSessionId()` accepts optional override string
- **`status.ts`, `mode.ts`, `darts.ts`, `budget.ts`** — Thread `params.session_id` to resolver
- **`scope.ts`** — Thread session_id + render resolved ID in help text
- **5 new tests** — One per handler verifying explicit session_id overrides env var

## Test Results

84 pass, 0 fail, 222 expect() calls. Full validation clean.

Closes #229

Generated with [Claude Code](https://claude.com/claude-code)