### PR TITLE
feat(scope): implement nerf_scope terminal monitor launcher

### DIFF
--- a/scope.ts
+++ b/scope.ts
@@ -1,38 +1,154 @@
 /**
- * nerf_scope tool handler (stub).
+ * nerf_scope tool handler.
  *
- * Returns a helpful message about the planned terminal monitor feature.
- * Full implementation deferred — scope requires terminal detection and
- * process spawning that is complex enough to warrant its own issue.
+ * Spawns `cc-context watch --session <id>` in a new terminal window.
+ * Detects the terminal emulator from $TERM_PROGRAM and launches a
+ * detached process that outlives the MCP request.
  */
 
-import { resolveSessionId } from "./session.ts";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+/** Path to the cc-context CLI script. */
+const CC_CONTEXT_PATH = join(
+  homedir(),
+  ".claude",
+  "context-crystallizer",
+  "bin",
+  "cc-context",
+);
+
+/** Terminal emulator launch commands keyed by TERM_PROGRAM value. */
+const TERMINAL_COMMANDS: Record<string, (cmd: string, args: string[]) => string[]> = {
+  ghostty: (cmd, args) => ["ghostty", "-e", cmd, ...args],
+  alacritty: (cmd, args) => ["alacritty", "-e", cmd, ...args],
+  kitty: (cmd, args) => ["kitty", cmd, ...args],
+};
+
+/** Fallback terminal launchers tried in order. */
+const FALLBACK_TERMINALS = ["x-terminal-emulator", "xterm"];
+
+/**
+ * Detect the terminal emulator and return the spawn arguments.
+ *
+ * Returns { terminal, argv } on success, or null if no terminal found.
+ */
+export function buildTerminalCommand(
+  ccContextPath: string,
+  sessionId: string | null,
+): { terminal: string; argv: string[] } | null {
+  const termProgram = process.env.TERM_PROGRAM?.toLowerCase();
+  const watchArgs = sessionId
+    ? ["watch", "--session", sessionId]
+    : ["watch"];
+
+  // Check known terminals from TERM_PROGRAM
+  if (termProgram && TERMINAL_COMMANDS[termProgram]) {
+    const argv = TERMINAL_COMMANDS[termProgram](ccContextPath, watchArgs);
+    return { terminal: termProgram, argv };
+  }
+
+  // Try fallbacks (skip in test mode to avoid spawning real terminals)
+  if (process.env.NERF_SCOPE_NO_FALLBACK === "1") {
+    return null;
+  }
+  for (const fallback of FALLBACK_TERMINALS) {
+    try {
+      const which = Bun.spawnSync(["which", fallback]);
+      if (which.exitCode === 0) {
+        return {
+          terminal: fallback,
+          argv: [fallback, "-e", ccContextPath, ...watchArgs],
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
 
 /**
  * Handle the nerf_scope tool call.
  *
- * Accepts an optional `interval` parameter (acknowledged in response)
- * but does not use it — the full monitor is not yet implemented.
+ * Spawns cc-context watch in a new terminal window. Returns a
+ * confirmation message or a helpful fallback with the manual command.
  */
 export async function handleScope(
   params: Record<string, unknown>,
 ): Promise<string> {
-  const sessionId = resolveSessionId(params.session_id as string | undefined);
+  // Only use session_id for cc-context when explicitly provided by the caller.
+  // Auto-resolved IDs (PID hashes) are synthetic and won't match real transcripts.
+  // When null, cc-context falls back to history.jsonl (most recent session).
+  const explicitSessionId = params.session_id as string | undefined ?? null;
   const interval = params.interval as number | undefined;
 
-  const lines = [
-    "nerf_scope is not yet implemented in the MCP server.",
-    "",
-    "To monitor context usage, use the crystallizer's built-in tracking",
-    `or run: cc-context watch --session ${sessionId}`,
-  ];
+  // Resolve cc-context path (allow override for testing)
+  const ccContextPath = process.env.NERF_CC_CONTEXT_PATH ?? CC_CONTEXT_PATH;
 
-  if (interval !== undefined) {
-    lines.push("");
-    lines.push(
-      `(Requested interval: ${interval}ms — will be used when the monitor is implemented)`,
-    );
+  if (!existsSync(ccContextPath)) {
+    return [
+      "Error: cc-context not found at expected path.",
+      `Expected: ${ccContextPath}`,
+      "",
+      "Install the context-crystallizer first:",
+      "  cd <claudecode-workflow> && ./install.sh --crystallizer",
+    ].join("\n");
   }
 
+  const termCmd = buildTerminalCommand(ccContextPath, explicitSessionId);
+
+  if (!termCmd) {
+    // No terminal detected — return manual command
+    const cmdStr = explicitSessionId
+      ? `cc-context watch --session ${explicitSessionId}`
+      : "cc-context watch";
+    const lines = [
+      "Could not detect a terminal emulator ($TERM_PROGRAM is not set).",
+      "",
+      "Run manually in a separate terminal:",
+      `  ${cmdStr}`,
+    ];
+    if (interval !== undefined) {
+      lines.push("");
+      lines.push(`(Requested interval: ${interval}ms — cc-context uses a fixed 5s poll)`);
+    }
+    return lines.join("\n");
+  }
+
+  // Spawn the terminal as a detached process (skip in dry-run / test mode)
+  if (process.env.NERF_SCOPE_DRY_RUN !== "1") {
+    const [command, ...args] = termCmd.argv;
+    try {
+      const child = spawn(command, args, {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const cmdStr = explicitSessionId
+        ? `cc-context watch --session ${explicitSessionId}`
+        : "cc-context watch";
+      return [
+        `Failed to launch ${termCmd.terminal}: ${msg}`,
+        "",
+        "Run manually in a separate terminal:",
+        `  ${cmdStr}`,
+      ].join("\n");
+    }
+  }
+
+  const label = explicitSessionId
+    ? `session ${explicitSessionId.slice(0, 8)}`
+    : "current session";
+  const lines = [
+    `Scope monitor launched in ${termCmd.terminal} for ${label}`,
+  ];
+  if (interval !== undefined) {
+    lines.push(`(Requested interval: ${interval}ms — cc-context uses a fixed 5s poll)`);
+  }
   return lines.join("\n");
 }

--- a/tests/scope.test.ts
+++ b/tests/scope.test.ts
@@ -1,41 +1,186 @@
 /**
- * Unit tests for scope.ts — nerf_scope stub handler.
+ * Unit tests for scope.ts — nerf_scope tool handler.
+ *
+ * handleScope tests use NERF_SCOPE_DRY_RUN=1 to prevent actual terminal spawns.
+ * buildTerminalCommand tests are pure (no side effects).
  */
 
-import { describe, test, expect } from "bun:test";
-import { handleScope } from "../scope.ts";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, unlinkSync, chmodSync } from "node:fs";
+import { handleScope, buildTerminalCommand } from "../scope.ts";
 
 describe("nerf_scope", () => {
-  test("scope returns not-implemented message", async () => {
+  let fakeCcContext: string;
+
+  beforeEach(() => {
+    // Create a fake cc-context script so existsSync passes
+    fakeCcContext = `/tmp/fake-cc-context-${Date.now()}`;
+    writeFileSync(fakeCcContext, "#!/bin/bash\nexit 0\n");
+    chmodSync(fakeCcContext, 0o755);
+    process.env.NERF_CC_CONTEXT_PATH = fakeCcContext;
+    // Prevent actual terminal spawns during tests
+    process.env.NERF_SCOPE_DRY_RUN = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.NERF_CC_CONTEXT_PATH;
+    delete process.env.NERF_SCOPE_DRY_RUN;
+    delete process.env.TERM_PROGRAM;
+    delete process.env.NERF_SCOPE_NO_FALLBACK;
+    try { unlinkSync(fakeCcContext); } catch { /* ignore */ }
+  });
+
+  test("scope returns error when cc-context not found", async () => {
+    process.env.NERF_CC_CONTEXT_PATH = "/nonexistent/cc-context";
+
     const result = await handleScope({});
 
-    expect(result).toContain("nerf_scope is not yet implemented");
+    expect(result).toContain("Error: cc-context not found");
+    expect(result).toContain("install.sh --crystallizer");
+  });
+
+  test("scope returns fallback when no terminal detected", async () => {
+    delete process.env.TERM_PROGRAM;
+    process.env.NERF_SCOPE_NO_FALLBACK = "1";
+
+    const result = await handleScope({});
+
+    expect(result).toContain("Could not detect a terminal emulator");
     expect(result).toContain("cc-context watch");
+    // Without explicit session_id, should NOT include --session
+    expect(result).not.toContain("--session");
   });
 
-  test("scope does not throw", async () => {
-    // Should return cleanly, not crash
+  test("scope fallback includes --session when explicitly provided", async () => {
+    delete process.env.TERM_PROGRAM;
+    process.env.NERF_SCOPE_NO_FALLBACK = "1";
+
+    const result = await handleScope({ session_id: "abc-123-def" });
+
+    expect(result).toContain("cc-context watch --session abc-123-def");
+  });
+
+  test("scope launches without --session when no explicit ID", async () => {
+    process.env.TERM_PROGRAM = "ghostty";
+
     const result = await handleScope({});
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
+
+    expect(result).toContain("Scope monitor launched");
+    expect(result).toContain("ghostty");
+    expect(result).toContain("current session");
   });
 
-  test("scope acknowledges interval parameter", async () => {
+  test("scope launches with session label when explicit ID provided", async () => {
+    process.env.TERM_PROGRAM = "ghostty";
+
+    const result = await handleScope({ session_id: "abcdef01-2345-6789" });
+
+    expect(result).toContain("Scope monitor launched");
+    expect(result).toContain("ghostty");
+    expect(result).toContain("session abcdef01");
+  });
+
+  test("scope acknowledges interval param", async () => {
+    process.env.TERM_PROGRAM = "ghostty";
+
     const result = await handleScope({ interval: 15000 });
 
     expect(result).toContain("15000ms");
-    expect(result).toContain("will be used when the monitor is implemented");
-  });
-
-  test("scope includes explicit session_id in help text", async () => {
-    const result = await handleScope({ session_id: "my-test-session-abc" });
-
-    expect(result).toContain("cc-context watch --session my-test-session-abc");
   });
 
   test("scope without interval does not mention interval", async () => {
+    process.env.TERM_PROGRAM = "ghostty";
+
     const result = await handleScope({});
 
     expect(result).not.toContain("Requested interval");
+    expect(result).not.toContain("poll");
+  });
+});
+
+describe("buildTerminalCommand", () => {
+  afterEach(() => {
+    delete process.env.TERM_PROGRAM;
+  });
+
+  test("builds ghostty command with -e flag", () => {
+    process.env.TERM_PROGRAM = "ghostty";
+    const result = buildTerminalCommand("/usr/bin/cc-context", "sess-123");
+
+    expect(result).not.toBeNull();
+    expect(result!.terminal).toBe("ghostty");
+    expect(result!.argv[0]).toBe("ghostty");
+    expect(result!.argv).toContain("-e");
+    expect(result!.argv).toContain("/usr/bin/cc-context");
+    expect(result!.argv).toContain("watch");
+    expect(result!.argv).toContain("--session");
+    expect(result!.argv).toContain("sess-123");
+  });
+
+  test("builds kitty command without -e flag", () => {
+    process.env.TERM_PROGRAM = "kitty";
+    const result = buildTerminalCommand("/usr/bin/cc-context", "sess-456");
+
+    expect(result).not.toBeNull();
+    expect(result!.terminal).toBe("kitty");
+    expect(result!.argv[0]).toBe("kitty");
+    expect(result!.argv).not.toContain("-e");
+    expect(result!.argv).toContain("/usr/bin/cc-context");
+    expect(result!.argv).toContain("sess-456");
+  });
+
+  test("builds alacritty command with -e flag", () => {
+    process.env.TERM_PROGRAM = "alacritty";
+    const result = buildTerminalCommand("/usr/bin/cc-context", "sess-789");
+
+    expect(result).not.toBeNull();
+    expect(result!.terminal).toBe("alacritty");
+    expect(result!.argv[0]).toBe("alacritty");
+    expect(result!.argv).toContain("-e");
+    expect(result!.argv).toContain("sess-789");
+  });
+
+  test("omits --session when sessionId is null", () => {
+    process.env.TERM_PROGRAM = "ghostty";
+    const result = buildTerminalCommand("/usr/bin/cc-context", null);
+
+    expect(result).not.toBeNull();
+    expect(result!.argv).toContain("watch");
+    expect(result!.argv).not.toContain("--session");
+  });
+
+  test("includes --session when sessionId provided", () => {
+    process.env.TERM_PROGRAM = "ghostty";
+    const result = buildTerminalCommand("/usr/bin/cc-context", "my-session");
+
+    expect(result).not.toBeNull();
+    expect(result!.argv).toContain("--session");
+    expect(result!.argv).toContain("my-session");
+  });
+
+  test("unknown TERM_PROGRAM tries fallbacks", () => {
+    process.env.TERM_PROGRAM = "some-unknown-terminal";
+    const result = buildTerminalCommand("/usr/bin/cc-context", "sess-000");
+
+    // Result depends on what's installed — either a fallback or null
+    if (result !== null) {
+      expect(result.argv).toContain("/usr/bin/cc-context");
+      expect(result.argv).toContain("watch");
+    }
+  });
+
+  test("includes all required watch args in correct order", () => {
+    process.env.TERM_PROGRAM = "ghostty";
+    const result = buildTerminalCommand("/path/to/cc-context", "my-session-id");
+
+    expect(result).not.toBeNull();
+    const argv = result!.argv;
+    const watchIdx = argv.indexOf("watch");
+    const sessionIdx = argv.indexOf("--session");
+    const idIdx = argv.indexOf("my-session-id");
+
+    expect(watchIdx).toBeGreaterThan(0);
+    expect(sessionIdx).toBeGreaterThan(watchIdx);
+    expect(idIdx).toBe(sessionIdx + 1);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the `nerf_scope` stub with a real implementation that spawns `cc-context watch` in a new terminal window. Detects the terminal emulator from `$TERM_PROGRAM` and launches a detached process.

## Changes

- **scope.ts** — full rewrite: terminal detection (ghostty/alacritty/kitty + fallbacks), detached spawn with `unref()`, explicit-only session_id (synthetic IDs skipped)
- **tests/scope.test.ts** — 14 tests covering terminal detection, dry-run mode, session_id threading, error paths
- Dead `resolveSessionId` import removed

## Linked Issues

Closes Wave-Engineering/claudecode-workflow#232

## Test Plan

- `bun test` — 93 tests, 260 expects, all passing
- `./scripts/ci/validate.sh` — TypeScript lint + shellcheck + tests clean
- Live tested: `/nerf scope` opened Ghostty with cc-context watch dashboard
- Verified explicit session_id passes through to `--session` flag
- Verified omitted session_id launches without `--session` (cc-context uses history.jsonl)