### PR TITLE
fix(nerf): nerf_status percent ignores lifted ouch denominator

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -122,6 +122,13 @@ export async function getContextUsage(
     // The analyzer is a bash library — source it and call analyze_context
     const cmd = `bash -c 'source "${analyzerPath}" && analyze_context "${transcript}"'`;
 
+    // NOTE: We use Node's `execSync` here, which inherits the parent process's
+    // environment by default. If we ever migrate this call to `Bun.spawnSync`
+    // for performance, env inheritance behaves differently — Bun does NOT
+    // automatically forward runtime mutations of `process.env` to the child,
+    // so we'd need to pass `env: { ...process.env }` explicitly. Surfaced as
+    // a gotcha by the cc-workflow team during a multi-agent wave; preventive
+    // note for whoever touches this next.
     const raw = execSync(cmd, {
       encoding: "utf-8",
       timeout: 10000,

--- a/status.ts
+++ b/status.ts
@@ -53,7 +53,12 @@ export async function handleStatus(
   // Format context line
   let contextLine: string;
   if (contextUsage) {
-    const pct = Math.round(contextUsage.percent);
+    // Compute percent against the LOCAL config's ouch, not the analyzer's
+    // `percent` field. The upstream context-analyzer.sh computes its percent
+    // against its own hardcoded `limit` (the global crystallizer default),
+    // which diverges from the displayed denominator the moment a user lifts
+    // their nerf darts via nerf_darts/nerf_budget. See issue #15.
+    const pct = Math.round((contextUsage.total / config.darts.ouch) * 100);
     contextLine = `Context: ${formatTokenCount(contextUsage.total)}/${ouchStr} (${pct}%)`;
   } else {
     contextLine = "Context: unavailable";

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -2,11 +2,15 @@
  * Unit tests for status.ts — nerf_status tool handler.
  *
  * Tests use real filesystem operations with temp config files.
- * No mocking of internal modules.
+ * No mocking of internal modules. Tests that exercise the context-usage
+ * shell-out path inject a fake analyzer via NERF_ANALYZER_PATH (same
+ * pattern as tests/context.test.ts).
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
 import { configPath, writeConfig, DEFAULTS, type NerfConfig } from "../config.ts";
 import { handleStatus, formatTokenCount } from "../status.ts";
 
@@ -106,6 +110,162 @@ describe("nerf_status", () => {
     expect(lines[6]).toBe("");
     // Context line
     expect(lines[7]).toMatch(/^Context:/);
+  });
+});
+
+describe("nerf_status context line — issue #15 regression", () => {
+  // These tests exercise the real shell-out path through context.ts via the
+  // NERF_ANALYZER_PATH env var override, then assert that handleStatus renders
+  // the percent against the LOCAL nerf config's ouch — not against whatever
+  // `limit`/`percent` the analyzer returned. This is the bug argus surfaced
+  // immediately after #13 shipped: with lifted darts, the analyzer's percent
+  // (computed against its hardcoded global default) no longer matches the
+  // displayed denominator.
+  let testSessionId: string;
+  let tempDir: string;
+  let fakeProjectDir: string;
+  let transcriptPath: string;
+  let originalAnalyzerPath: string | undefined;
+
+  /**
+   * Helper: write a fake analyzer script and a fake transcript so getContextUsage
+   * resolves to a controlled ContextUsage value. Returns the analyzer path so
+   * the caller can set NERF_ANALYZER_PATH.
+   */
+  function installFakeAnalyzer(analyzerJson: string): string {
+    const fakeAnalyzer = join(tempDir, "fake-analyzer.sh");
+    writeFileSync(
+      fakeAnalyzer,
+      `#!/bin/bash
+analyze_context() {
+  cat <<'ENDJSON'
+${analyzerJson}
+ENDJSON
+}
+`,
+    );
+    chmodSync(fakeAnalyzer, 0o755);
+
+    // Fake transcript at the path findTranscript() searches.
+    mkdirSync(fakeProjectDir, { recursive: true });
+    writeFileSync(
+      transcriptPath,
+      JSON.stringify({
+        type: "assistant",
+        message: { model: "claude-sonnet-4-20250514", usage: { input_tokens: 1 } },
+      }) + "\n",
+    );
+
+    return fakeAnalyzer;
+  }
+
+  beforeEach(() => {
+    testSessionId = `test-status-pct-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    process.env.CLAUDE_SESSION_ID = testSessionId;
+    tempDir = mkdtempSync(join(tmpdir(), "nerf-status-pct-"));
+    // Use the unique testSessionId as part of the directory name so concurrent
+    // or rapid sequential test runs cannot collide on the same path.
+    fakeProjectDir = join(homedir(), ".claude", "projects", `-tmp-${testSessionId}`);
+    transcriptPath = join(fakeProjectDir, `${testSessionId}.jsonl`);
+    originalAnalyzerPath = process.env.NERF_ANALYZER_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_SESSION_ID;
+    if (originalAnalyzerPath === undefined) {
+      delete process.env.NERF_ANALYZER_PATH;
+    } else {
+      process.env.NERF_ANALYZER_PATH = originalAnalyzerPath;
+    }
+    try { rmSync(configPath(testSessionId), { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${configPath(testSessionId)}.tmp`, { force: true }); } catch { /* ignore */ }
+    try { rmSync(transcriptPath, { force: true }); } catch { /* ignore */ }
+    try { rmSync(fakeProjectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("percent uses local config.darts.ouch as denominator, not analyzer's stale percent", async () => {
+    // argus's exact case: lifted nerf ouch to 750k, context at 366k.
+    // Analyzer (oblivious to lifted darts) reports its own stale percent
+    // computed against its hardcoded 200k limit: 366/200 = 183%.
+    // The displayed line should ignore the analyzer's percent and compute
+    // its own against the lifted ouch: 366/750 = 49%.
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 500_000, hard: 650_000, ouch: 750_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const analyzerPath = installFakeAnalyzer(`{
+  "tokens": { "total": 366000 },
+  "limit": 200000,
+  "percent": 183.0,
+  "action": "compact"
+}`);
+    process.env.NERF_ANALYZER_PATH = analyzerPath;
+
+    const result = await handleStatus({});
+
+    // Numerator + denominator come from local config (366k context vs 750k ouch)
+    expect(result).toContain("Context: 366k/750k");
+    // Percent must be locally computed: 366/750 ≈ 0.488 → 49%
+    expect(result).toContain("(49%)");
+    // Must NOT carry through the analyzer's stale percent
+    expect(result).not.toContain("183");
+  });
+
+  test("percent computes against local ouch even when context is below the analyzer limit", async () => {
+    // Inverse case: nerf ouch lifted to 500k, context at 80k. Analyzer's
+    // percent (80/200 = 40%) and the correct percent (80/500 = 16%) differ
+    // and we should display the latter.
+    const config: NerfConfig = {
+      mode: "hurt-me-plenty",
+      darts: { soft: 300_000, hard: 400_000, ouch: 500_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const analyzerPath = installFakeAnalyzer(`{
+  "tokens": { "total": 80000 },
+  "limit": 200000,
+  "percent": 40.0,
+  "action": "none"
+}`);
+    process.env.NERF_ANALYZER_PATH = analyzerPath;
+
+    const result = await handleStatus({});
+
+    expect(result).toContain("Context: 80k/500k");
+    expect(result).toContain("(16%)");
+    expect(result).not.toContain("(40%)");
+  });
+
+  test("percent renders correctly when context exceeds local ouch", async () => {
+    // Context above ouch should display >100% (the user is in the ouch zone).
+    // Lock in this behavior so the fix doesn't accidentally cap at 100.
+    const config: NerfConfig = {
+      mode: "ultraviolence",
+      darts: { soft: 120_000, hard: 150_000, ouch: 200_000 },
+      session_id: testSessionId,
+    };
+    writeConfig(testSessionId, config);
+
+    const analyzerPath = installFakeAnalyzer(`{
+  "tokens": { "total": 240000 },
+  "limit": 200000,
+  "percent": 120.0,
+  "action": "compact"
+}`);
+    process.env.NERF_ANALYZER_PATH = analyzerPath;
+
+    const result = await handleStatus({});
+
+    expect(result).toContain("Context: 240k/200k");
+    // 240/200 = 120% — happens to match the analyzer in this case (same
+    // limit as the local config), but the assertion is on the value our
+    // code computes, not the value we forwarded.
+    expect(result).toContain("(120%)");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the `nerf_status` context-line display, which was rendering mathematically nonsensical percentages like `Context: 366k/750k (183%)` whenever a user lifted nerf darts above the upstream context-analyzer's hardcoded limit. Discovered by argus (cc-workflow team) immediately after #13 shipped, while running a 14-agent wave with lifted darts. This bug is latent-but-newly-visible — it only became reachable because the #13 fix made it possible for MCP clients to actually lift nerf darts in the first place.

## Changes

- **`status.ts` (one-line production fix)** — replaced `pct = Math.round(contextUsage.percent)` with `pct = Math.round((contextUsage.total / config.darts.ouch) * 100)`. The displayed numerator and denominator are unchanged; the percent now agrees with them. Inline comment explains the rationale and references #15.
- **`context.ts` (comment-only)** — preventive note near `execSync` at line 125, documenting that migrating to `Bun.spawnSync` for performance would require explicit `env: { ...process.env }` passing because Bun doesn't forward runtime env mutations to children. Surfaced as a gotcha by argus's wave team during separate debugging; bundled into this commit per BJ's pre-approval since it's a tiny adjacent preventive note.
- **`tests/status.test.ts` (3 new regression tests)** — uses the existing `NERF_ANALYZER_PATH` injection pattern from `tests/context.test.ts` to inject fake analyzers returning known stale percent values, then asserts `handleStatus` renders the locally-computed percent. Coverage:
  1. **argus's exact case** — 366k context, 750k ouch, fake analyzer reports stale `183%`, must display `49%`
  2. **Inverse case** — 80k context, 500k ouch, fake analyzer reports `40%`, must display `16%`
  3. **Context exceeds ouch case** — 240k context, 200k ouch, displays `120%` (locks in that the formula doesn't accidentally cap at 100% when in the ouch zone)

## Linked Issues

Closes #15

## Test Plan

- [x] `bun test` — 111 pass / 0 fail / 330 expect() calls (was 108 baseline; +3 new tests)
- [x] `bun run lint` (TypeScript strict) — clean
- [x] `scripts/ci/validate.sh` — full validation green (TypeScript + shellcheck + tests)
- [x] `feature-dev:code-reviewer` — one medium finding fixed before merge (race condition in test directory naming), one medium finding deferred (theoretical cleanup edge case the reviewer explicitly noted is already covered)
- [x] Verified the no-context "Context: unavailable" path is unchanged and still tested
- [x] All existing `tests/status.test.ts` tests continue to pass

## Notes

- Argus is still mid-wave on the workaround (won't restart MCP transport mid-flight), so this fix doesn't unblock anything in flight — but it removes the embarrassing display from `nerf_status` once the next session picks up the new binary.
- This fix is a precondition for the dev team rollout BJ has scheduled — a status tool that displays >100% for normal usage erodes trust immediately.
- Out-of-scope: a hand-crafted config file with `"ouch": 0` could still produce `Infinity%` because `readConfig` only substitutes defaults for null/undefined (not 0). Reachable only via direct file edit, not via the public tool API. Worth a separate `chore` issue if defensive clamping is desired.
