### PR TITLE
chore(ci): add chore/* and docs/* to ci.yml push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "feature/*", "fix/*"]
+    branches: ["main", "feature/*", "fix/*", "chore/*", "docs/*"]
   merge_group:
   pull_request:
     branches: ["main"]


### PR DESCRIPTION
## Summary

Add `chore/*` and `docs/*` to the `.github/workflows/ci.yml` push trigger branches array. Brings CI feedback parity to all four branch types defined in CLAUDE.md's "Branching Strategy" (`feature`, `fix`, `chore`, `docs`). Single-line additive change.

Surfaced during PR #18 (chore/17-ccfold) when `gh pr checks --watch` initially reported "no checks reported" until the pull_request event picked up the slack. Pre-fix behavior: chore/docs pushes were silently skipped on the push event. Post-fix: same fast-feedback loop as feature/fix branches.

## Changes

- **`.github/workflows/ci.yml` (single line, +1/-1)** — push trigger branches array goes from `["main", "feature/*", "fix/*"]` to `["main", "feature/*", "fix/*", "chore/*", "docs/*"]`. Existing patterns preserved, two new globs appended. No procedural logic added — complies with the new MANDATORY: No Procedural Logic in CI/CD YAML rule from #17.

## Linked Issues

Closes #19

## Test Plan

- [x] `bun test` — 111 pass / 0 fail / 330 expect() calls (unchanged from baseline; no code touched)
- [x] `scripts/ci/validate.sh` — full validation green (TypeScript + shellcheck + tests)
- [x] `feature-dev:code-reviewer` over the YAML change — reports "no issues found at medium risk or above", change is "correct, complete, and safe to merge"
- [x] **Self-validating AC verified live** — after pushing this `chore/*` branch with the fix in place, `gh run list --branch chore/19-ci-branch-trigger-gap` showed a `push` event CI run queued immediately. GitHub Actions evaluates workflow files from the branch being pushed, so the fix took effect on this very branch before merge. Compare to PR #18's pre-fix behavior, where the same query returned "no checks reported" until the pull_request event fired
- [x] Verified `release.yml` has no equivalent gap (it's tag-triggered only)
- [x] Verified the `merge_group:` trigger is unaffected — it uses GitHub's queue machinery independently of `push.branches` matching
- [x] Verified the new trigger doesn't introduce any side effects on the existing `pull_request` trigger or required-status-checks

## Notes

- **The proof landed in the same step as the deploy.** Most CI fixes only take effect after merging to main, so you have to trust the change. Here the validation was observable in real time on the branch itself.
- **CI cost trade-off:** chore/docs branches now fire CI on every push instead of only on PR open. For this repo's volume and ~20-second workflow duration, the exposure is negligible. Net win for fast feedback.
- **No follow-up work needed.** The fix is complete and self-contained. Stale `origin/feature/*` remote-tracking refs (10 of them) are a separate housekeeping item I flagged earlier — say the word and I'll prune them.
