### PR TITLE
fix(deps): bump fast-uri to 3.1.3 and hono to 4.12.30 to clear 3 HIGH CVEs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,10 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "3.1.3",
+    "hono": "4.12.30",
+  },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
@@ -80,7 +84,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -100,7 +104,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "fast-uri": "3.1.3",
+    "hono": "4.12.30"
   }
 }


### PR DESCRIPTION
## Summary

Clears 3 HIGH CVEs reported by `trivy fs --scanners vuln --severity HIGH,CRITICAL` against this repo's dependency tree, ahead of the fleet-wide install window. Both affected packages are transitive deps via `@modelcontextprotocol/sdk@1.29.0`.

| CVE | Package | Before | After | Fixed in |
|---|---|---|---|---|
| CVE-2026-6321 | fast-uri | 3.1.0 | 3.1.3 | 3.1.1 |
| CVE-2026-6322 | fast-uri | 3.1.0 | 3.1.3 | 3.1.2 |
| CVE-2026-54290 | hono | 4.12.10 | 4.12.30 | 4.12.25 |

## Changes

- `package.json`: added an `overrides` block pinning `fast-uri` 3.1.3 and `hono` 4.12.30
- `bun.lock`: regenerated; the only package-line changes are those two versions

## Note on mechanism

Neither package is a direct dependency, so this **introduces an `overrides` block to this repo**, which had none. That is a new mechanism here, though not new to the family — `mcp-server-sdlc` already carries the equivalent block.

The pins are **exact**, deviating from sdlc's caret style (`^3.1.2` / `^4.12.25`). Caret ranges would today resolve to fast-uri 3.1.4 / hono 4.12.31 — newer than, and therefore not, the versions sdlc has actually field-proven. The resulting `bun.lock` integrity hashes for both packages are byte-identical to sdlc's.

## Linked Issues

Closes #28

## Test Plan

Actually run on this branch:

- `trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --quiet .`
  - before: **1 manifest parsed** (`bun.lock`), **3 HIGH findings**
  - after: **1 manifest parsed** (`bun.lock`), **0 findings**
- `bun test` — **140 pass, 0 fail**, 363 expect() calls, exit 0 (identical to the pre-change baseline, so no regression)
- `./scripts/ci/validate.sh` — exit 0: `bunx tsc --noEmit` clean, shellcheck 5 files OK, 140 pass / 0 fail
