### PR TITLE
chore(version): align hardcoded version literals to 1.2.4

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -137,7 +137,7 @@ const HANDLERS: Record<
 };
 
 const server = new Server(
-  { name: "nerf-server", version: "1.0.0" },
+  { name: "nerf-server", version: "1.2.4" },
   { capabilities: { tools: {} } }
 );
 
@@ -191,4 +191,4 @@ process.on("SIGINT", () => {
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info("startup", { version: "1.0.0", config: { tools: TOOLS.length } });
+log.info("startup", { version: "1.2.4", config: { tools: TOOLS.length } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-nerf",
-  "version": "1.0.0",
+  "version": "1.2.4",
   "description": "MCP server for deterministic context budget management in Claude Code",
   "type": "module",
   "scripts": {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -17,7 +17,7 @@ import { TOOLS } from "../index.ts";
 
 function createServer(): Server {
   const server = new Server(
-    { name: "nerf-server", version: "1.0.0" },
+    { name: "nerf-server", version: "1.2.4" },
     { capabilities: { tools: {} } }
   );
 


### PR DESCRIPTION
## Summary

The repo's latest tag is `v1.2.3` but source still carried the `1.0.0` scaffold default from initial bootstrap, never updated across releases. Aligns hardcoded version literals to `1.2.4` so `main` can be tagged `v1.2.4` at head.

## Changes

- `index.ts:140` — MCP server identity `{ name: "nerf-server", version: "1.0.0" }` → `1.2.4`
- `index.ts:194` — startup log `version: "1.0.0"` → `1.2.4`
- `package.json:3` — `"version": "1.0.0"` → `1.2.4`
- `tests/server.test.ts:20` — mock `Server` construction mirroring `index.ts:140`'s `nerf-server` identity → `1.2.4`

Not changed (out of scope, verified not to describe this package's version):
- `tests/server.test.ts:73` — `{ name: "test-client", version: "1.0.0" }` is a generic MCP client stub identity, unrelated to nerf-server's own version
- `CLAUDE.md:214-215` — `git tag v1.0.0` is illustrative example syntax in the release doc
- `scripts/install-remote.sh:12` — `--version v1.0.0` is an example CLI invocation in a usage comment
- `package.json` `overrides` block (`fast-uri 3.1.3`, `hono 4.12.30`) — CVE pins, untouched
- `package.json` `name` field — untouched (changing it would dirty `bun.lock`)
- `bun.lock` — untouched; confirmed via md5 unchanged before/after `bun install` and after the full test run

## Linked Issues

Closes #30

## Test Plan

- Baseline (`main` @ `c92db93`, before edits): `scripts/ci/validate.sh` → exit 0, 140 pass / 0 fail
- After edits: `scripts/ci/validate.sh` → exit 0, 140 pass / 0 fail (identical counts; no test asserted the literal `"1.0.0"` string, so only the mirroring fixture at `tests/server.test.ts:20` needed a value bump)
- `bun.lock` md5 verified identical before and after `bun install` and after the full validate run
- `git status` verified to show only `index.ts`, `package.json`, `tests/server.test.ts` staged
